### PR TITLE
Add initial PorkPress SSL network plugin

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Admin functionality for PorkPress SSL.
+ *
+ * @package PorkPress\SSL
+ */
+
+namespace PorkPress\SSL;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Admin
+ */
+class Admin {
+	/**
+	 * Initialize hooks.
+	 */
+	public function init() {
+		add_action( 'network_admin_menu', array( $this, 'register_menu' ) );
+	}
+
+	/**
+	 * Register the network admin menu.
+	 */
+	public function register_menu() {
+		add_menu_page(
+			__( 'PorkPress SSL', 'porkpress-ssl' ),
+			__( 'PorkPress SSL', 'porkpress-ssl' ),
+			'manage_network',
+			'porkpress-ssl',
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Render the plugin page.
+	 */
+	public function render_page() {
+		$active_tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : 'dashboard';
+
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'PorkPress SSL', 'porkpress-ssl' ) . '</h1>';
+		echo '<h2 class="nav-tab-wrapper">';
+		$tabs = array(
+			'dashboard' => __( 'Dashboard', 'porkpress-ssl' ),
+			'domains'   => __( 'Domains', 'porkpress-ssl' ),
+			'settings'  => __( 'Settings', 'porkpress-ssl' ),
+			'logs'      => __( 'Logs', 'porkpress-ssl' ),
+		);
+
+		foreach ( $tabs as $tab => $label ) {
+			$class = ( $active_tab === $tab ) ? ' nav-tab-active' : '';
+			printf(
+				'<a href="%1$s" class="nav-tab%3$s">%2$s</a>',
+				esc_url( add_query_arg( 'tab', $tab, network_admin_url( 'admin.php?page=porkpress-ssl' ) ) ),
+				esc_html( $label ),
+				esc_attr( $class )
+			);
+		}
+
+		echo '</h2>';
+
+		switch ( $active_tab ) {
+			case 'domains':
+				echo '<p>' . esc_html__( 'Domains content coming soon.', 'porkpress-ssl' ) . '</p>';
+				break;
+			case 'settings':
+				echo '<p>' . esc_html__( 'Settings content coming soon.', 'porkpress-ssl' ) . '</p>';
+				break;
+			case 'logs':
+				echo '<p>' . esc_html__( 'Logs content coming soon.', 'porkpress-ssl' ) . '</p>';
+				break;
+			case 'dashboard':
+			default:
+				echo '<p>' . esc_html__( 'Dashboard content coming soon.', 'porkpress-ssl' ) . '</p>';
+				break;
+		}
+
+		echo '</div>';
+	}
+}

--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Domain service.
+ *
+ * @package PorkPress\SSL
+ */
+
+namespace PorkPress\SSL;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Domain_Service
+ */
+class Domain_Service {
+	// Placeholder for domain management.
+}

--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Logging utility.
+ *
+ * @package PorkPress\SSL
+ */
+
+namespace PorkPress\SSL;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Logger
+ */
+class Logger {
+	// Placeholder for logging.
+}

--- a/includes/class-porkbun-client.php
+++ b/includes/class-porkbun-client.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Porkbun API client.
+ *
+ * @package PorkPress\SSL
+ */
+
+namespace PorkPress\SSL;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Porkbun_Client
+ */
+class Porkbun_Client {
+	// Placeholder for API interactions.
+}

--- a/includes/class-reconciler.php
+++ b/includes/class-reconciler.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Reconciler for keeping state in sync.
+ *
+ * @package PorkPress\SSL
+ */
+
+namespace PorkPress\SSL;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Reconciler
+ */
+class Reconciler {
+	// Placeholder for reconciliation logic.
+}

--- a/includes/class-ssl-service.php
+++ b/includes/class-ssl-service.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * SSL service.
+ *
+ * @package PorkPress\SSL
+ */
+
+namespace PorkPress\SSL;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class SSL_Service
+ */
+class SSL_Service {
+	// Placeholder for SSL certificate management.
+}

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Plugin Name:       PorkPress SSL
+ * Description:       Manage SSL certificates via Porkbun.
+ * Version:           0.1.0
+ * Requires at least: 6.0
+ * Requires PHP:      8.1
+ * Network:           true
+ * Author:            PorkPress
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       porkpress-ssl
+ * Domain Path:       /languages
+ *
+ * @package PorkPress\SSL
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const PORKPRESS_SSL_VERSION = '0.1.0';
+require_once __DIR__ . '/includes/class-admin.php';
+require_once __DIR__ . '/includes/class-porkbun-client.php';
+require_once __DIR__ . '/includes/class-domain-service.php';
+require_once __DIR__ . '/includes/class-ssl-service.php';
+require_once __DIR__ . '/includes/class-logger.php';
+require_once __DIR__ . '/includes/class-reconciler.php';
+
+/**
+ * Activation hook callback.
+ */
+function porkpress_ssl_activate() {
+	// Placeholder for activation logic.
+}
+register_activation_hook( __FILE__, 'porkpress_ssl_activate' );
+
+/**
+ * Deactivation hook callback.
+ */
+function porkpress_ssl_deactivate() {
+	// Placeholder for deactivation logic.
+}
+register_deactivation_hook( __FILE__, 'porkpress_ssl_deactivate' );
+
+/**
+ * Initialize the plugin.
+ */
+function porkpress_ssl_init() {
+	$admin = new \PorkPress\SSL\Admin();
+	$admin->init();
+}
+add_action( 'plugins_loaded', 'porkpress_ssl_init' );


### PR DESCRIPTION
## Summary
- scaffold PorkPress SSL network-only plugin with activation/deactivation hooks and PHP 8.1 requirement
- add network admin page with Dashboard, Domains, Settings, and Logs tabs
- stub out service classes for Porkbun API, domain/SSL management, logging, and reconciliation

## Testing
- `find . -name '*.php' -print -exec php -l {} \;`
- `phpcs --standard=WordPress --ignore=vendor -p .`

------
https://chatgpt.com/codex/tasks/task_e_68972aff0f888333b0d987c32932599d