### PR TITLE
Add logging system and admin log viewer

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -87,7 +87,7 @@ case 'settings':
 $this->render_settings_tab();
 break;
 case 'logs':
-echo '<p>' . esc_html__( 'Logs content coming soon.', 'porkpress-ssl' ) . '</p>';
+$this->render_logs_tab();
 break;
 case 'dashboard':
 default:
@@ -168,6 +168,60 @@ echo '</tr>';
 echo '</table>';
 submit_button();
 echo '</form>';
+}
+
+/**
+ * Render the logs tab for the network admin page.
+ */
+public function render_logs_tab() {
+if ( ! current_user_can( \PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS ) ) {
+return;
+}
+
+$severity = isset( $_GET['severity'] ) ? sanitize_key( wp_unslash( $_GET['severity'] ) ) : '';
+
+if ( isset( $_GET['export'] ) && 'csv' === $_GET['export'] ) {
+$logs = Logger::get_logs( array( 'severity' => $severity, 'limit' => 0 ) );
+header( 'Content-Type: text/csv' );
+header( 'Content-Disposition: attachment; filename="porkpress-logs.csv"' );
+$fh = fopen( 'php://output', 'w' );
+fputcsv( $fh, array( 'time', 'user', 'action', 'context', 'result', 'severity' ) );
+foreach ( $logs as $log ) {
+$user = $log['user_id'] ? get_userdata( $log['user_id'] ) : null;
+fputcsv( $fh, array( $log['time'], $user ? $user->user_login : '', $log['action'], $log['context'], $log['result'], $log['severity'] ) );
+}
+exit;
+}
+
+$logs = Logger::get_logs( array( 'severity' => $severity ) );
+
+echo '<form method="get">';
+echo '<input type="hidden" name="page" value="porkpress-ssl" />';
+echo '<input type="hidden" name="tab" value="logs" />';
+echo '<select name="severity">';
+echo '<option value="">' . esc_html__( 'All Severities', 'porkpress-ssl' ) . '</option>';
+foreach ( array( 'info', 'warn', 'error' ) as $sev ) {
+echo '<option value="' . esc_attr( $sev ) . '"' . selected( $severity, $sev, false ) . '>' . esc_html( ucfirst( $sev ) ) . '</option>';
+}
+echo '</select> ';
+submit_button( __( 'Filter', 'porkpress-ssl' ), 'secondary', '', false );
+echo ' <a class="button" href="' . esc_url( add_query_arg( array( 'export' => 'csv' ) ) ) . '">' . esc_html__( 'Export CSV', 'porkpress-ssl' ) . '</a>';
+echo '</form>';
+
+echo '<table class="widefat fixed">';
+echo '<thead><tr><th>' . esc_html__( 'Time', 'porkpress-ssl' ) . '</th><th>' . esc_html__( 'User', 'porkpress-ssl' ) . '</th><th>' . esc_html__( 'Action', 'porkpress-ssl' ) . '</th><th>' . esc_html__( 'Context', 'porkpress-ssl' ) . '</th><th>' . esc_html__( 'Result', 'porkpress-ssl' ) . '</th><th>' . esc_html__( 'Severity', 'porkpress-ssl' ) . '</th></tr></thead><tbody>';
+foreach ( $logs as $log ) {
+$user = $log['user_id'] ? get_userdata( $log['user_id'] ) : null;
+echo '<tr>';
+echo '<td>' . esc_html( $log['time'] ) . '</td>';
+echo '<td>' . esc_html( $user ? $user->user_login : '' ) . '</td>';
+echo '<td>' . esc_html( $log['action'] ) . '</td>';
+echo '<td><code>' . esc_html( $log['context'] ) . '</code></td>';
+echo '<td>' . esc_html( $log['result'] ) . '</td>';
+echo '<td>' . esc_html( $log['severity'] ) . '</td>';
+echo '</tr>';
+}
+echo '</tbody></table>';
 }
 
 /**

--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -13,5 +13,125 @@ defined( 'ABSPATH' ) || exit;
  * Class Logger
  */
 class Logger {
-	// Placeholder for logging.
+
+/**
+ * Get the logs table name.
+ *
+ * @return string
+ */
+public static function get_table_name() {
+global $wpdb;
+return $wpdb->base_prefix . 'porkpress_logs';
+}
+
+/**
+ * Create the logs table if it does not exist.
+ */
+public static function create_table() {
+global $wpdb;
+$table_name      = self::get_table_name();
+$charset_collate = $wpdb->get_charset_collate();
+
+$sql = "CREATE TABLE {$table_name} (
+id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+time datetime NOT NULL,
+user_id bigint(20) unsigned NOT NULL,
+action varchar(191) NOT NULL,
+context longtext NULL,
+result varchar(191) NOT NULL,
+severity varchar(20) NOT NULL,
+PRIMARY KEY  (id),
+KEY time (time),
+KEY severity (severity)
+) {$charset_collate};";
+
+require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+dbDelta( $sql );
+}
+
+/**
+ * Insert a log entry.
+ *
+ * @param string $action   Action name.
+ * @param array  $context  Context data.
+ * @param string $result   Result message.
+ * @param string $severity Log severity.
+ */
+public static function log( $action, $context = array(), $result = '', $severity = 'info' ) {
+global $wpdb;
+$wpdb->insert(
+self::get_table_name(),
+array(
+'time'     => current_time( 'mysql' ),
+'user_id'  => get_current_user_id(),
+'action'   => $action,
+'context'  => wp_json_encode( $context ),
+'result'   => $result,
+'severity' => $severity,
+)
+);
+}
+
+/**
+ * Convenience info logger.
+ *
+ * @param string $action  Action name.
+ * @param array  $context Context data.
+ * @param string $result  Result message.
+ */
+public static function info( $action, $context = array(), $result = '' ) {
+self::log( $action, $context, $result, 'info' );
+}
+
+/**
+ * Convenience warning logger.
+ *
+ * @param string $action  Action name.
+ * @param array  $context Context data.
+ * @param string $result  Result message.
+ */
+public static function warn( $action, $context = array(), $result = '' ) {
+self::log( $action, $context, $result, 'warn' );
+}
+
+/**
+ * Convenience error logger.
+ *
+ * @param string $action  Action name.
+ * @param array  $context Context data.
+ * @param string $result  Result message.
+ */
+public static function error( $action, $context = array(), $result = '' ) {
+self::log( $action, $context, $result, 'error' );
+}
+
+/**
+ * Retrieve log entries.
+ *
+ * @param array $args Query arguments.
+ *
+ * @return array
+ */
+public static function get_logs( $args = array() ) {
+global $wpdb;
+$defaults = array(
+'severity' => '',
+'limit'    => 100,
+);
+$args   = wp_parse_args( $args, $defaults );
+$where  = '1=1';
+$params = array();
+if ( ! empty( $args['severity'] ) ) {
+$where    .= ' AND severity = %s';
+$params[] = $args['severity'];
+}
+
+$limit_clause = $args['limit'] > 0 ? $wpdb->prepare( ' LIMIT %d', $args['limit'] ) : '';
+$sql          = 'SELECT * FROM ' . self::get_table_name() . " WHERE {$where} ORDER BY time DESC{$limit_clause}";
+if ( $params ) {
+$sql = $wpdb->prepare( $sql, $params );
+}
+
+return $wpdb->get_results( $sql, ARRAY_A );
+}
 }

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.2
+ * Version:           0.1.3
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.2';
+const PORKPRESS_SSL_VERSION = '0.1.3';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 require_once __DIR__ . '/includes/class-admin.php';
@@ -33,6 +33,7 @@ require_once __DIR__ . '/includes/class-reconciler.php';
  * Activation hook callback.
  */
 function porkpress_ssl_activate() {
+        \PorkPress\SSL\Logger::create_table();
         // Grant request capability to site administrators on all sites.
         if ( is_multisite() ) {
                 foreach ( get_sites() as $site ) {


### PR DESCRIPTION
## Summary
- add database logger with helper methods
- create logs admin tab to view and export entries
- bump plugin version

## Testing
- `php -l porkpress-ssl.php`
- `php -l includes/class-logger.php`
- `php -l includes/class-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689762a39cdc83339b87e9e05c280456