### PR TITLE
Add domains tab with domain listing and filters

### DIFF
--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -13,5 +13,31 @@ defined( 'ABSPATH' ) || exit;
  * Class Domain_Service
  */
 class Domain_Service {
-	// Placeholder for domain management.
+        /**
+         * Porkbun API client.
+         *
+         * @var Porkbun_Client
+         */
+        protected Porkbun_Client $client;
+
+        /**
+         * Constructor.
+         */
+        public function __construct() {
+                $api_key    = defined( 'PORKPRESS_API_KEY' ) ? PORKPRESS_API_KEY : get_site_option( 'porkpress_ssl_api_key', '' );
+                $api_secret = defined( 'PORKPRESS_API_SECRET' ) ? PORKPRESS_API_SECRET : get_site_option( 'porkpress_ssl_api_secret', '' );
+                $this->client = new Porkbun_Client( $api_key, $api_secret );
+        }
+
+        /**
+         * List domains.
+         *
+         * @param int $page     Page number.
+         * @param int $per_page Domains per page.
+         *
+         * @return array|Porkbun_Client_Error
+         */
+        public function list_domains( int $page = 1, int $per_page = 100 ) {
+                return $this->client->listDomains( $page, $per_page );
+        }
 }

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.4
+ * Version:           0.1.5
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.4';
+const PORKPRESS_SSL_VERSION = '0.1.5';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 require_once __DIR__ . '/includes/class-admin.php';


### PR DESCRIPTION
## Summary
- bump plugin version to 0.1.5
- add Domain_Service wrapper for Porkbun API and network Domains tab UI
- display domains table with search, status and expiry filters

## Testing
- `phpunit tests/BackoffTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68977a20cdbc8333b3a461e75e738d96