### PR TITLE
Improve Porkbun HTTP error messages

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -113,7 +113,11 @@ class Admin {
                 $service = new Domain_Service();
                 $result  = $service->list_domains();
                 if ( $result instanceof Porkbun_Client_Error ) {
-                        printf( '<div class="error"><p>%s</p></div>', esc_html( $result->message ) );
+                        $message = $result->message;
+                        if ( $result->status ) {
+                                $message = sprintf( 'HTTP %d: %s', $result->status, $message );
+                        }
+                        printf( '<div class="error"><p>%s</p></div>', esc_html( $message ) );
                         return;
                 }
 

--- a/includes/class-porkbun-client.php
+++ b/includes/class-porkbun-client.php
@@ -157,9 +157,16 @@ class Porkbun_Client {
 				continue;
 			}
 
-			return new Porkbun_Client_Error( 'http_error', 'HTTP error', $status, $body );
-		}
-	}
+                        $data    = json_decode( $body, true );
+                        $message = $body;
+                        if ( is_array( $data ) && isset( $data['message'] ) ) {
+                                $message = $data['message'];
+                        }
+                        $message = sprintf( 'HTTP %d: %s', $status, $message );
+
+                        return new Porkbun_Client_Error( 'http_error', $message, $status, $data ?? $body );
+                }
+        }
 
 	/**
 	 * Low-level HTTP request using cURL.


### PR DESCRIPTION
## Summary
- surface HTTP status and API message when Porkbun requests fail
- show detailed Porkbun error messages in Domains tab

## Testing
- `php -l includes/class-porkbun-client.php`
- `php -l includes/class-admin.php`
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689780e5ee9c83339cd5cc4bff714288