### PR TITLE
Detect missing Porkbun API credentials

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -111,7 +111,15 @@ class Admin {
                 $expiry_window = isset( $_GET['expiry'] ) ? absint( wp_unslash( $_GET['expiry'] ) ) : 0;
 
                 $service = new Domain_Service();
-                $result  = $service->list_domains();
+                if ( ! $service->has_credentials() ) {
+                        printf(
+                                '<div class="error"><p>%s</p></div>',
+                                esc_html__( 'Porkbun API credentials are missing. Please configure them in the Settings tab.', 'porkpress-ssl' )
+                        );
+                        return;
+                }
+
+                $result = $service->list_domains();
                 if ( $result instanceof Porkbun_Client_Error ) {
                         printf( '<div class="error"><p>%s</p></div>', esc_html( $result->message ) );
                         return;

--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -21,12 +21,29 @@ class Domain_Service {
         protected Porkbun_Client $client;
 
         /**
+         * Whether the API credentials are missing.
+         */
+        protected bool $missing_credentials = false;
+
+        /**
          * Constructor.
          */
         public function __construct() {
                 $api_key    = defined( 'PORKPRESS_API_KEY' ) ? PORKPRESS_API_KEY : get_site_option( 'porkpress_ssl_api_key', '' );
                 $api_secret = defined( 'PORKPRESS_API_SECRET' ) ? PORKPRESS_API_SECRET : get_site_option( 'porkpress_ssl_api_secret', '' );
+
+                if ( empty( $api_key ) || empty( $api_secret ) ) {
+                        $this->missing_credentials = true;
+                }
+
                 $this->client = new Porkbun_Client( $api_key, $api_secret );
+        }
+
+        /**
+         * Whether the service has the required API credentials.
+         */
+        public function has_credentials(): bool {
+                return ! $this->missing_credentials;
         }
 
         /**


### PR DESCRIPTION
## Summary
- Track presence of Porkbun API credentials in Domain_Service
- Show admin notice and skip domain listing when credentials are missing

## Testing
- `php -l includes/class-domain-service.php`
- `php -l includes/class-admin.php`
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689780ee7f5483338b0d8d99346bc12a