### PR TITLE
Force https scheme on plugin admin page site icon

### DIFF
--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -81,7 +81,16 @@ register_deactivation_hook( __FILE__, 'porkpress_ssl_deactivate' );
  */
 function porkpress_ssl_init() {
         $admin = new \PorkPress\SSL\Admin();
-        $admin->init();
+       $admin->init();
+
+       if ( is_network_admin() && isset( $_GET['page'] ) && 'porkpress-ssl' === $_GET['page'] ) {
+               add_filter(
+                       'get_site_icon_url',
+                       function ( $url ) {
+                               return set_url_scheme( $url, 'https' );
+                       }
+               );
+       }
 }
 add_action( 'plugins_loaded', 'porkpress_ssl_init' );
 


### PR DESCRIPTION
## Summary
- Ensure plugin's network admin page uses https for the site icon URL
- Scope get_site_icon_url filter to only run on the PorkPress SSL network admin screen

## Testing
- `php -l porkpress-ssl.php`
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689780fa4f588333bd09f939c317908a