### PR TITLE
Fix Porkbun API base URL and ensure log table

### DIFF
--- a/includes/class-porkbun-client.php
+++ b/includes/class-porkbun-client.php
@@ -35,7 +35,7 @@ class Porkbun_Client {
 	 *
 	 * @var string
 	 */
-	private string $base_url = 'https://porkbun.com/api/json/v3/';
+	private string $base_url = 'https://api.porkbun.com/api/json/v3/';
 
 	/**
 	 * API key.
@@ -76,9 +76,10 @@ class Porkbun_Client {
 	 * List domains with pagination.
 	 */
 	public function listDomains( int $page = 1, int $per_page = 100 ) {
-		return $this->request( 'domains/list', [
-			'page'	  => $page,
-			'perpage' => $per_page,
+		$start = max( 0, ( $page - 1 ) * $per_page );
+
+		return $this->request( 'domain/listAll', [
+			'start' => (string) $start,
 		] );
 	}
 

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -80,6 +80,13 @@ register_deactivation_hook( __FILE__, 'porkpress_ssl_deactivate' );
  * Initialize the plugin.
  */
 function porkpress_ssl_init() {
+        global $wpdb;
+
+        $table_name = \PorkPress\SSL\Logger::get_table_name();
+        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
+                \PorkPress\SSL\Logger::create_table();
+        }
+
         $admin = new \PorkPress\SSL\Admin();
        $admin->init();
 


### PR DESCRIPTION
## Summary
- use proper `api.porkbun.com` base URL and `domain/listAll` endpoint for listing domains
- create PorkPress log table on init if missing

## Testing
- `php -l includes/class-porkbun-client.php`
- `php -l porkpress-ssl.php`
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689784f2384083338790285894e5de74