### PR TITLE
Map domain type and expiry in domain listings

### DIFF
--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -50,11 +50,33 @@ class Domain_Service {
          * List domains.
          *
          * @param int $page     Page number.
-         * @param int $per_page Domains per page.
-         *
-         * @return array|Porkbun_Client_Error
-         */
-        public function list_domains( int $page = 1, int $per_page = 100 ) {
-                return $this->client->listDomains( $page, $per_page );
-        }
+        * @param int $per_page Domains per page.
+        *
+        * @return array|Porkbun_Client_Error
+        */
+       public function list_domains( int $page = 1, int $per_page = 100 ) {
+               $result = $this->client->listDomains( $page, $per_page );
+
+               if ( $result instanceof Porkbun_Client_Error ) {
+                       return $result;
+               }
+
+               if ( isset( $result['domains'] ) && is_array( $result['domains'] ) ) {
+                       $result['domains'] = array_map(
+                               function ( $domain ) {
+                                       if ( isset( $domain['tld'] ) && ! isset( $domain['type'] ) ) {
+                                               $domain['type'] = $domain['tld'];
+                                       }
+                                       if ( isset( $domain['expireDate'] ) && ! isset( $domain['expiry'] ) ) {
+                                               $domain['expiry'] = $domain['expireDate'];
+                                       }
+
+                                       return $domain;
+                               },
+                               $result['domains']
+                       );
+               }
+
+               return $result;
+       }
 }

--- a/tests/DomainServiceTest.php
+++ b/tests/DomainServiceTest.php
@@ -1,0 +1,45 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ );
+}
+require_once __DIR__ . '/../includes/class-domain-service.php';
+require_once __DIR__ . '/../includes/class-porkbun-client.php';
+
+class DomainServiceTest extends TestCase {
+    public function testListDomainsMapsTypeAndExpiry() {
+        $mock = new class extends \PorkPress\SSL\Porkbun_Client {
+            public function __construct() {}
+            public function listDomains( int $page = 1, int $per_page = 100 ) {
+                return [
+                    'status'  => 'SUCCESS',
+                    'domains' => [
+                        [
+                            'domain'     => 'example.com',
+                            'status'     => 'ACTIVE',
+                            'tld'        => 'com',
+                            'expireDate' => '2024-01-01',
+                        ],
+                    ],
+                ];
+            }
+        };
+
+        $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
+            public function __construct( $client ) {
+                $this->client = $client;
+                $this->missing_credentials = false;
+            }
+        };
+
+        $result = $service->list_domains();
+        $domain = $result['domains'][0];
+
+        $this->assertArrayHasKey( 'type', $domain );
+        $this->assertArrayHasKey( 'expiry', $domain );
+        $this->assertSame( 'com', $domain['type'] );
+        $this->assertSame( '2024-01-01', $domain['expiry'] );
+    }
+}
+


### PR DESCRIPTION
## Summary
- Map `tld` and `expireDate` fields from Porkbun API to `type` and `expiry`
- Add unit test verifying Domain_Service includes type and expiry

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68978d6befd483339ead18610e63fd56