### PR TITLE
Add domain bulk actions with queue and logging

### DIFF
--- a/assets/domain-bulk.js
+++ b/assets/domain-bulk.js
@@ -1,0 +1,32 @@
+jQuery(function($){
+    $('#porkpress-domain-actions').on('submit', function(e){
+        e.preventDefault();
+        var domains = $('input[name="domains[]"]:checked').map(function(){return $(this).val();}).get();
+        var action = $('select[name="bulk_action"]').val();
+        var site = $('input[name="site_id"]').val();
+        if(!domains.length || !action){return;}
+        var total = domains.length, processed = 0;
+        var $progress = $('#porkpress-domain-progress');
+        $progress.text('0/'+total);
+        function next(){
+            if(!domains.length){$progress.text('Done');return;}
+            var domain = domains.shift();
+            $.post(porkpressBulk.ajaxUrl, {
+                action: 'porkpress_ssl_bulk_action',
+                nonce: porkpressBulk.nonce,
+                domain: domain,
+                bulk_action: action,
+                site_id: site
+            }, function(resp){
+                processed++;
+                if(!resp.success){console.error('Action failed', domain, resp.data);}
+                $progress.text(processed + '/' + total);
+                next();
+            });
+        }
+        next();
+    });
+    $('#cb-select-all').on('change', function(){
+        $('input[name="domains[]"]').prop('checked', this.checked);
+    });
+});

--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -79,4 +79,60 @@ class Domain_Service {
 
                return $result;
        }
+
+       /**
+        * Attach a domain to a site.
+        *
+        * @param string $domain Domain name.
+        * @param int    $site_id Site ID.
+        *
+        * @return bool|Porkbun_Client_Error
+        */
+       public function attach_to_site( string $domain, int $site_id ) {
+               if ( function_exists( 'update_site_meta' ) ) {
+                       update_site_meta( $site_id, 'porkpress_domain', $domain );
+               }
+
+               return true;
+       }
+
+       /**
+        * Detach a domain from any site.
+        *
+        * @param string $domain Domain name.
+        *
+        * @return bool
+        */
+       public function detach_from_site( string $domain ): bool {
+               if ( function_exists( 'get_sites' ) && function_exists( 'delete_site_meta' ) ) {
+                       $sites = get_sites( array( 'meta_key' => 'porkpress_domain', 'meta_value' => $domain ) );
+                       foreach ( $sites as $site ) {
+                               delete_site_meta( $site->blog_id, 'porkpress_domain', $domain );
+                       }
+               }
+
+               return true;
+       }
+
+       /**
+        * Disable a domain in Porkbun.
+        *
+        * @param string $domain Domain name.
+        *
+        * @return array|Porkbun_Client_Error
+        */
+       public function disable_domain( string $domain ) {
+               return $this->client->disableDomain( $domain );
+       }
+
+       /**
+        * Remove a domain from Porkbun.
+        *
+        * @param string $domain Domain name.
+        *
+        * @return array|Porkbun_Client_Error
+        */
+       public function remove_domain( string $domain ) {
+               return $this->client->deleteDomain( $domain );
+       }
 }

--- a/includes/class-porkbun-client.php
+++ b/includes/class-porkbun-client.php
@@ -75,13 +75,27 @@ class Porkbun_Client {
 	/**
 	 * List domains with pagination.
 	 */
-	public function listDomains( int $page = 1, int $per_page = 100 ) {
-		$start = max( 0, ( $page - 1 ) * $per_page );
+        public function listDomains( int $page = 1, int $per_page = 100 ) {
+                $start = max( 0, ( $page - 1 ) * $per_page );
 
-		return $this->request( 'domain/listAll', [
-			'start' => (string) $start,
-		] );
-	}
+                return $this->request( 'domain/listAll', [
+                        'start' => (string) $start,
+                ] );
+        }
+
+       /**
+        * Disable a domain.
+        */
+       public function disableDomain( string $domain ) {
+               return $this->request( "domain/disableDomain/{$domain}", [] );
+       }
+
+       /**
+        * Delete a domain from Porkbun.
+        */
+       public function deleteDomain( string $domain ) {
+               return $this->request( "domain/deleteDomain/{$domain}", [] );
+       }
 
 	/**
 	 * Retrieve DNS records for a domain.

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.6
+ * Version:           0.1.7
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.6';
+const PORKPRESS_SSL_VERSION = '0.1.7';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 require_once __DIR__ . '/includes/class-admin.php';


### PR DESCRIPTION
## Summary
- increment plugin version to 0.1.7
- add bulk domain actions (attach/detach/disable/remove) with queued progress UI
- log action results via AJAX handler

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_6897948fc4288333aa7ed313fd74696d