### PR TITLE
Add domain alias table and CRUD helpers

### DIFF
--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.7
+ * Version:           0.1.8
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.7';
+const PORKPRESS_SSL_VERSION = '0.1.8';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 require_once __DIR__ . '/includes/class-admin.php';
@@ -34,6 +34,7 @@ require_once __DIR__ . '/includes/class-reconciler.php';
  */
 function porkpress_ssl_activate() {
         \PorkPress\SSL\Logger::create_table();
+       \PorkPress\SSL\Domain_Service::create_alias_table();
         // Grant request capability to site administrators on all sites.
         if ( is_multisite() ) {
                 foreach ( get_sites() as $site ) {
@@ -82,10 +83,15 @@ register_deactivation_hook( __FILE__, 'porkpress_ssl_deactivate' );
 function porkpress_ssl_init() {
         global $wpdb;
 
-        $table_name = \PorkPress\SSL\Logger::get_table_name();
-        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
-                \PorkPress\SSL\Logger::create_table();
-        }
+       $table_name = \PorkPress\SSL\Logger::get_table_name();
+       if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
+               \PorkPress\SSL\Logger::create_table();
+       }
+
+       $alias_table = \PorkPress\SSL\Domain_Service::get_alias_table_name();
+       if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $alias_table ) ) !== $alias_table ) {
+               \PorkPress\SSL\Domain_Service::create_alias_table();
+       }
 
         $admin = new \PorkPress\SSL\Admin();
        $admin->init();

--- a/tests/DomainServiceTest.php
+++ b/tests/DomainServiceTest.php
@@ -4,6 +4,84 @@ use PHPUnit\Framework\TestCase;
 if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', __DIR__ );
 }
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $str ) {
+        return $str;
+    }
+}
+if ( ! defined( 'ARRAY_A' ) ) {
+    define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+class MockWpdb {
+    public $data = [];
+    public $base_prefix = 'wp_';
+
+    public function get_charset_collate() {
+        return '';
+    }
+
+    public function prepare( $query, $args ) {
+        if ( ! is_array( $args ) ) {
+            $args = func_get_args();
+            array_shift( $args );
+        }
+        $args = array_map( function ( $a ) {
+            return is_int( $a ) ? $a : "'{$a}'";
+        }, $args );
+
+        return vsprintf( $query, $args );
+    }
+
+    private function table_from_sql( $sql ) {
+        if ( preg_match( '/FROM\s+(\w+)/', $sql, $m ) ) {
+            return $m[1];
+        }
+        return '';
+    }
+
+    public function insert( $table, $data, $format ) {
+        $this->data[ $table ][] = $data;
+        return 1;
+    }
+
+    public function get_results( $sql, $output ) {
+        $table = $this->table_from_sql( $sql );
+        $rows  = $this->data[ $table ] ?? [];
+        if ( preg_match( '/site_id\s*=\s*(\d+)/', $sql, $m ) ) {
+            $site_id = (int) $m[1];
+            $rows    = array_filter( $rows, fn( $r ) => $r['site_id'] == $site_id );
+        }
+        if ( preg_match( "/domain\s*=\s*'([^']+)'/", $sql, $m ) ) {
+            $domain = $m[1];
+            $rows   = array_filter( $rows, fn( $r ) => $r['domain'] == $domain );
+        }
+        return array_values( $rows );
+    }
+
+    public function update( $table, $data, $where, $formats, $where_formats ) {
+        foreach ( $this->data[ $table ] as &$row ) {
+            if ( $row['site_id'] == $where['site_id'] && $row['domain'] == $where['domain'] ) {
+                foreach ( $data as $k => $v ) {
+                    $row[ $k ] = $v;
+                }
+                return 1;
+            }
+        }
+        return false;
+    }
+
+    public function delete( $table, $where, $where_formats ) {
+        foreach ( $this->data[ $table ] as $i => $row ) {
+            if ( $row['site_id'] == $where['site_id'] && $row['domain'] == $where['domain'] ) {
+                unset( $this->data[ $table ][ $i ] );
+                $this->data[ $table ] = array_values( $this->data[ $table ] );
+                return 1;
+            }
+        }
+        return false;
+    }
+}
 require_once __DIR__ . '/../includes/class-domain-service.php';
 require_once __DIR__ . '/../includes/class-porkbun-client.php';
 
@@ -40,6 +118,32 @@ class DomainServiceTest extends TestCase {
         $this->assertArrayHasKey( 'expiry', $domain );
         $this->assertSame( 'com', $domain['type'] );
         $this->assertSame( '2024-01-01', $domain['expiry'] );
+    }
+
+    public function testAliasCrud() {
+        global $wpdb;
+        $wpdb = new MockWpdb();
+
+        $service = new class extends \PorkPress\SSL\Domain_Service {
+            public function __construct() {}
+        };
+
+        $table = $service::get_alias_table_name();
+
+        $this->assertTrue( $service->add_alias( 1, 'example.com', true, 'active' ) );
+
+        $aliases = $service->get_aliases( 1 );
+        $this->assertCount( 1, $aliases );
+        $this->assertSame( 'example.com', $aliases[0]['domain'] );
+        $this->assertSame( 1, $aliases[0]['is_primary'] );
+
+        $service->update_alias( 1, 'example.com', [ 'status' => 'inactive', 'is_primary' => false ] );
+        $alias = $service->get_aliases( 1 )[0];
+        $this->assertSame( 'inactive', $alias['status'] );
+        $this->assertSame( 0, $alias['is_primary'] );
+
+        $service->delete_alias( 1, 'example.com' );
+        $this->assertCount( 0, $service->get_aliases( 1 ) );
     }
 }
 


### PR DESCRIPTION
## Summary
- add wp_porkpress_domain_aliases table and CRUD helpers in `Domain_Service`
- initialize custom alias table on activation and plugin load
- bump plugin version to 0.1.8

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_6897de028f148333942367d0e5cb7e5b