### PR TITLE
Add sunrise drop-in for domain aliasing

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -20,7 +20,23 @@ class Admin {
                 add_action( 'network_admin_menu', array( $this, 'register_network_menu' ) );
                 add_action( 'admin_menu', array( $this, 'register_site_menu' ) );
                add_action( 'wp_ajax_porkpress_ssl_bulk_action', array( $this, 'handle_bulk_action' ) );
+               add_action( 'admin_notices', array( $this, 'sunrise_notice' ) );
+               add_action( 'network_admin_notices', array( $this, 'sunrise_notice' ) );
         }
+
+       /**
+        * Display a notice if SUNRISE is not enabled.
+        */
+       public function sunrise_notice() {
+               if ( ! is_multisite() || defined( 'SUNRISE' ) || ! current_user_can( 'manage_network' ) ) {
+                       return;
+               }
+
+               printf(
+                       '<div class="notice notice-warning"><p>%s</p></div>',
+                       esc_html__( "Add define('SUNRISE', true); to wp-config.php to enable domain aliasing.", 'porkpress-ssl' )
+               );
+       }
 
         /**
          * Register the network admin menu.

--- a/includes/sunrise-loader.php
+++ b/includes/sunrise-loader.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Sunrise loader for PorkPress SSL.
+ *
+ * Maps incoming domains to sites using alias table.
+ *
+ * @package PorkPress\\SSL
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_filter(
+    'pre_get_site_by_path',
+    static function ( $site, $domain, $path, $segments ) {
+        global $wpdb;
+
+        $table = $wpdb->base_prefix . 'porkpress_domain_aliases';
+        $domain = strtolower( preg_replace( '/:\d+$/', '', $domain ) );
+        $row   = $wpdb->get_row( $wpdb->prepare( "SELECT site_id FROM {$table} WHERE domain = %s", $domain ) );
+
+        if ( ! $row ) {
+            return $site;
+        }
+
+        $site = get_site( (int) $row->site_id );
+        if ( ! $site ) {
+            return $site;
+        }
+
+        $primary = $wpdb->get_var(
+            $wpdb->prepare( "SELECT domain FROM {$table} WHERE site_id = %d AND is_primary = 1 LIMIT 1", $row->site_id )
+        );
+
+        if ( $primary ) {
+            $site->domain = $primary;
+        }
+
+        return $site;
+    },
+    1,
+    4
+);

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.8
+ * Version:           0.1.9
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.8';
+const PORKPRESS_SSL_VERSION = '0.1.9';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 require_once __DIR__ . '/includes/class-admin.php';

--- a/sunrise.php
+++ b/sunrise.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Sunrise drop-in loader for PorkPress SSL.
+ *
+ * Copy this file to wp-content/sunrise.php and add
+ * define('SUNRISE', true); to wp-config.php.
+ *
+ * @package PorkPress\\SSL
+ */
+
+if ( defined( 'WP_PLUGIN_DIR' ) ) {
+    $loader = WP_PLUGIN_DIR . '/porkpress-ssl/includes/sunrise-loader.php';
+    if ( file_exists( $loader ) ) {
+        require $loader;
+    }
+}


### PR DESCRIPTION
## Summary
- add sunrise loader to map domain aliases to site IDs
- warn administrators to enable SUNRISE in wp-config.php
- bump plugin to version 0.1.9

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_6897e07a52808333a6b322fe7771c936