### PR TITLE
feat: support site creation when attaching domain

### DIFF
--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.9
+ * Version:           0.1.10
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.9';
+const PORKPRESS_SSL_VERSION = '0.1.10';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 require_once __DIR__ . '/includes/class-admin.php';


### PR DESCRIPTION
## Summary
- bump plugin version to 0.1.10
- allow attaching a domain by creating a new site with alias and URL updates
- extend admin bulk action handler for new site creation parameters

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_6897e295339c8333b2d284a983185332