### PR TITLE
Archive site when Porkbun domain removed

### DIFF
--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -347,7 +347,42 @@ KEY domain (domain)
                        )
                );
 
-               return false !== $result;
+       return false !== $result;
+   }
+
+   /**
+    * Determine whether a domain is active in Porkbun.
+    *
+    * @param string $domain Domain name.
+    *
+    * @return bool True if the domain exists and is active, false otherwise.
+    */
+   public function is_domain_active( string $domain ): bool {
+       $result = $this->client->listDomains();
+
+       if ( $result instanceof Porkbun_Client_Error ) {
+           // If the API fails, assume active to avoid false positives.
+           return true;
        }
+
+       if ( empty( $result['domains'] ) || ! is_array( $result['domains'] ) ) {
+           return false;
+       }
+
+       foreach ( $result['domains'] as $info ) {
+           if ( ! isset( $info['domain'] ) ) {
+               continue;
+           }
+
+           if ( strtolower( $info['domain'] ) === strtolower( $domain ) ) {
+               $status = strtoupper( $info['status'] ?? 'ACTIVE' );
+
+               return 'ACTIVE' === $status;
+           }
+       }
+
+       // Domain not found.
+       return false;
+   }
 
 }

--- a/includes/class-reconciler.php
+++ b/includes/class-reconciler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Reconciler for keeping state in sync.
+ * Reconciler for keeping state in sync with Porkbun.
  *
  * @package PorkPress\SSL
  */
@@ -13,5 +13,66 @@ defined( 'ABSPATH' ) || exit;
  * Class Reconciler
  */
 class Reconciler {
-	// Placeholder for reconciliation logic.
+    /**
+     * Domain service instance.
+     *
+     * @var Domain_Service
+     */
+    protected Domain_Service $domains;
+
+    /**
+     * Constructor.
+     *
+     * @param Domain_Service|null $domains Optional domain service instance.
+     */
+    public function __construct( ?Domain_Service $domains = null ) {
+        $this->domains = $domains ?: new Domain_Service();
+    }
+
+    /**
+     * Reconcile a single site's primary domain with Porkbun.
+     *
+     * If the primary domain is disabled or removed, the site is archived and
+     * all aliases are unmapped.
+     *
+     * @param int $site_id Site ID.
+     *
+     * @return bool True if the site was archived, false otherwise.
+     */
+    public function reconcile_site( int $site_id ): bool {
+        $aliases = $this->domains->get_aliases( $site_id );
+
+        if ( empty( $aliases ) ) {
+            return false;
+        }
+
+        $primary = null;
+        foreach ( $aliases as $alias ) {
+            if ( ! empty( $alias['is_primary'] ) ) {
+                $primary = $alias['domain'];
+                break;
+            }
+        }
+
+        if ( ! $primary ) {
+            return false;
+        }
+
+        if ( $this->domains->is_domain_active( $primary ) ) {
+            return false;
+        }
+
+        if ( function_exists( 'update_blog_status' ) ) {
+            update_blog_status( $site_id, 'archived', 1 );
+        } elseif ( function_exists( 'wp_update_site' ) ) {
+            wp_update_site( $site_id, array( 'archived' => 1 ) );
+        }
+
+        foreach ( $aliases as $alias ) {
+            $this->domains->delete_alias( $site_id, $alias['domain'] );
+        }
+
+        return true;
+    }
 }
+

--- a/includes/sunrise-loader.php
+++ b/includes/sunrise-loader.php
@@ -27,6 +27,13 @@ add_filter(
             return $site;
         }
 
+        if ( ! empty( $site->archived ) ) {
+            header( 'HTTP/1.1 410 Gone' );
+            header( 'Content-Type: text/html; charset=utf-8' );
+            echo '<!DOCTYPE html><html><head><meta charset="utf-8"><title>Site Offline</title></head><body><h1>Site Offline</h1><p>This site is currently unavailable.</p></body></html>';
+            exit;
+        }
+
         $primary = $wpdb->get_var(
             $wpdb->prepare( "SELECT domain FROM {$table} WHERE site_id = %d AND is_primary = 1 LIMIT 1", $row->site_id )
         );

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.11
+ * Version:           0.1.12
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.11';
+const PORKPRESS_SSL_VERSION = '0.1.12';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 require_once __DIR__ . '/includes/class-admin.php';

--- a/tests/ReconcilerTest.php
+++ b/tests/ReconcilerTest.php
@@ -1,0 +1,60 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ );
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $str ) {
+        return $str;
+    }
+}
+if ( ! function_exists( 'update_blog_status' ) ) {
+    function update_blog_status( $site_id, $pref, $value ) {
+        global $updated_sites;
+        $updated_sites[ $site_id ][ $pref ] = $value;
+    }
+}
+if ( ! defined( 'ARRAY_A' ) ) {
+    define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+require_once __DIR__ . '/../includes/class-domain-service.php';
+require_once __DIR__ . '/../includes/class-porkbun-client.php';
+require_once __DIR__ . '/../includes/class-reconciler.php';
+require_once __DIR__ . '/DomainServiceTest.php'; // For MockWpdb class.
+
+class ReconcilerTest extends TestCase {
+    public function testArchivesSiteWhenPrimaryDomainMissing() {
+        global $wpdb, $updated_sites;
+        $wpdb = new MockWpdb();
+        $updated_sites = [];
+
+        $client = new class extends \PorkPress\SSL\Porkbun_Client {
+            public function __construct() {}
+            public function listDomains( int $page = 1, int $per_page = 100 ) {
+                // Return empty list so domain is treated as missing.
+                return [ 'status' => 'SUCCESS', 'domains' => [] ];
+            }
+        };
+
+        $service = new class( $client ) extends \PorkPress\SSL\Domain_Service {
+            public function __construct( $client ) {
+                $this->client = $client;
+                $this->missing_credentials = false;
+            }
+        };
+
+        // Add aliases to the mock table.
+        $service->add_alias( 1, 'gone.com', true );
+        $service->add_alias( 1, 'alias.com', false );
+
+        $reconciler = new \PorkPress\SSL\Reconciler( $service );
+        $result = $reconciler->reconcile_site( 1 );
+
+        $this->assertTrue( $result );
+        $this->assertSame( 1, $updated_sites[1]['archived'] );
+        $this->assertCount( 0, $service->get_aliases( 1 ) );
+    }
+}
+


### PR DESCRIPTION
## Summary
- archive site and unmap aliases when primary Porkbun domain is missing
- display friendly offline page for archived sites
- bump plugin version to 0.1.12

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_6897e94721d483339d51f923b5f9c51e