### PR TITLE
Add dry‑run mode with simulation tools

### DIFF
--- a/includes/class-porkbun-client-dryrun.php
+++ b/includes/class-porkbun-client-dryrun.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Dry-run Porkbun API client.
+ *
+ * Records planned requests without performing external HTTP calls.
+ *
+ * @package PorkPress\SSL
+ */
+
+namespace PorkPress\SSL;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Porkbun_Client_DryRun
+ */
+class Porkbun_Client_DryRun extends Porkbun_Client {
+    /**
+     * Recorded request plan.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $plan = array();
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function request( string $endpoint, array $payload, string $method = 'POST' ) {
+        $this->plan[] = array(
+            'endpoint' => $endpoint,
+            'payload'  => $payload,
+            'method'   => $method,
+        );
+
+        if ( 'domain/listAll' === $endpoint ) {
+            return array( 'status' => 'SUCCESS', 'domains' => array() );
+        }
+
+        return array( 'status' => 'SUCCESS' );
+    }
+}

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -24,6 +24,7 @@ const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 require_once __DIR__ . '/includes/class-admin.php';
 require_once __DIR__ . '/includes/class-porkbun-client.php';
+require_once __DIR__ . '/includes/class-porkbun-client-dryrun.php';
 require_once __DIR__ . '/includes/class-domain-service.php';
 require_once __DIR__ . '/includes/class-ssl-service.php';
 require_once __DIR__ . '/includes/class-logger.php';

--- a/tests/DryRunTest.php
+++ b/tests/DryRunTest.php
@@ -1,0 +1,39 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ );
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $str ) {
+        return $str;
+    }
+}
+if ( ! function_exists( 'get_site_option' ) ) {
+    function get_site_option( $key, $default = '' ) {
+        return $default;
+    }
+}
+if ( ! defined( 'ARRAY_A' ) ) {
+    define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+require_once __DIR__ . '/DomainServiceTest.php'; // For MockWpdb.
+require_once __DIR__ . '/../includes/class-porkbun-client.php';
+require_once __DIR__ . '/../includes/class-porkbun-client-dryrun.php';
+require_once __DIR__ . '/../includes/class-domain-service.php';
+
+class DryRunTest extends TestCase {
+    public function testDryRunRecordsPlan() {
+        global $wpdb;
+        $wpdb = new MockWpdb();
+
+        $service = new \PorkPress\SSL\Domain_Service( null, true );
+        $result  = $service->list_domains();
+        $plan    = $service->get_plan();
+
+        $this->assertSame( 'SUCCESS', $result['status'] );
+        $this->assertNotEmpty( $plan );
+        $this->assertSame( 'domain/listAll', $plan[0]['endpoint'] );
+    }
+}


### PR DESCRIPTION
## Summary
- Add dry-run mode toggle to settings
- Simulate reconciliation plans on domain and site alias pages
- Track dry-run requests without external API calls

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_6897fa9c4bc483339b4695b00468be1d