### PR TITLE
feat: add DNS health check and clean domain table

### DIFF
--- a/assets/domain-bulk.js
+++ b/assets/domain-bulk.js
@@ -9,6 +9,9 @@ jQuery(function($){
         if(action === 'detach'){
             override = prompt('Type CONFIRM to detach selected domains');
             if(override !== 'CONFIRM'){return;}
+        } else if(action === 'attach'){
+            override = prompt('Type CONFIRM to override DNS check');
+            if(override === null){return;}
         }
         var total = domains.length, processed = 0;
         var $progress = $('#porkpress-domain-progress');
@@ -25,7 +28,10 @@ jQuery(function($){
                 override: override
             }, function(resp){
                 processed++;
-                if(!resp.success){console.error('Action failed', domain, resp.data);}
+                if(!resp.success){
+                    console.error('Action failed', domain, resp.data);
+                    alert('Action failed for ' + domain + ': ' + resp.data);
+                }
                 $progress.text(processed + '/' + total);
                 next();
             });

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -247,24 +247,21 @@ class Admin {
                echo '<thead><tr>';
                echo '<td class="manage-column column-cb check-column"><input type="checkbox" id="cb-select-all" /></td>';
                echo '<th>' . esc_html__( 'Name', 'porkpress-ssl' ) . '</th>';
-               echo '<th>' . esc_html__( 'Type', 'porkpress-ssl' ) . '</th>';
                echo '<th>' . esc_html__( 'Expiry', 'porkpress-ssl' ) . '</th>';
                echo '<th>' . esc_html__( 'DNS Status', 'porkpress-ssl' ) . '</th>';
                echo '</tr></thead><tbody>';
 
                 if ( empty( $domains ) ) {
-                       echo '<tr><td colspan="5">' . esc_html__( 'No domains found.', 'porkpress-ssl' ) . '</td></tr>';
+               echo '<tr><td colspan="4">' . esc_html__( 'No domains found.', 'porkpress-ssl' ) . '</td></tr>';
                 } else {
                         foreach ( $domains as $domain ) {
-                                $name       = $domain['domain'] ?? $domain['name'] ?? '';
-                                $type       = $domain['type'] ?? '';
-                                $expiry     = $domain['expiry'] ?? $domain['expiration'] ?? $domain['exdate'] ?? '';
-                                $dns_status = $domain['status'] ?? $domain['dnsstatus'] ?? '';
+                               $name       = $domain['domain'] ?? $domain['name'] ?? '';
+                               $expiry     = $domain['expiry'] ?? $domain['expiration'] ?? $domain['exdate'] ?? '';
+                               $dns_status = $domain['status'] ?? $domain['dnsstatus'] ?? '';
 
                                echo '<tr>';
                                echo '<th scope="row" class="check-column"><input type="checkbox" name="domains[]" value="' . esc_attr( $name ) . '" /></th>';
                                echo '<td>' . esc_html( $name ) . '</td>';
-                               echo '<td>' . esc_html( $type ) . '</td>';
                                echo '<td>' . esc_html( $expiry ) . '</td>';
                                echo '<td>' . esc_html( $dns_status ) . '</td>';
                                echo '</tr>';
@@ -308,6 +305,13 @@ class Admin {
 
                switch ( $action ) {
                        case 'attach':
+                               if ( 'CONFIRM' !== strtoupper( $override ) ) {
+                                       $check = $service->check_dns_health( $domain );
+                                       if ( is_wp_error( $check ) ) {
+                                               wp_send_json_error( $check->get_error_message() );
+                                       }
+                               }
+
                                if ( $site_id > 0 ) {
                                        $result = $service->attach_to_site( $domain, $site_id );
                                } else {

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.15
+ * Version:           0.1.16
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.15';
+const PORKPRESS_SSL_VERSION = '0.1.16';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 require_once __DIR__ . '/includes/class-admin.php';


### PR DESCRIPTION
## Summary
- remove domain type column from network admin table
- block domain mapping when DNS doesn't point to this network unless override provided
- bump plugin version to 0.1.16

## Testing
- `php -l includes/class-admin.php`
- `php -l includes/class-domain-service.php`
- `php -l porkpress-ssl.php`
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_6898045ab8288333b948e737ff3dee86