### PR TITLE
Add TXT propagation waiter and bump version

### DIFF
--- a/includes/class-txt-propagation-waiter.php
+++ b/includes/class-txt-propagation-waiter.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * TXT propagation waiter.
+ *
+ * Polls multiple resolvers for _acme-challenge TXT records until found or timeout.
+ *
+ * @package PorkPress\SSL
+ */
+
+namespace PorkPress\SSL;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class TXT_Propagation_Waiter
+ */
+class TXT_Propagation_Waiter {
+        /**
+         * DNS resolvers to query.
+         *
+         * @var array<int, string>
+         */
+        protected array $resolvers;
+
+        /**
+         * Constructor.
+         *
+         * @param array<int, string> $resolvers Resolver IPs.
+         */
+        public function __construct( array $resolvers = array( '8.8.8.8', '1.1.1.1' ) ) {
+                $this->resolvers = $resolvers;
+        }
+
+        /**
+         * Wait for TXT record propagation.
+         *
+         * Polls all resolvers until the TXT record exists (and optionally matches
+         * the provided value) or the timeout is reached.
+         *
+         * @param string      $domain  Domain without the _acme-challenge prefix.
+         * @param string|null $value   Optional TXT value to match.
+         * @param int         $timeout Maximum time to wait in seconds.
+         * @param int         $sleep   Sleep interval between checks in seconds.
+         *
+         * @return bool True if record found on all resolvers, false on timeout.
+         */
+        public function wait( string $domain, ?string $value = null, int $timeout = 60, int $sleep = 5 ): bool {
+                $deadline = time() + $timeout;
+                $name     = '_acme-challenge.' . $domain;
+
+                do {
+                        $all_found = true;
+                        foreach ( $this->resolvers as $resolver ) {
+                                $records = $this->query_txt( $name, $resolver );
+                                if ( empty( $records ) ) {
+                                        $all_found = false;
+                                        break;
+                                }
+                                if ( null !== $value && ! in_array( $value, $records, true ) ) {
+                                        $all_found = false;
+                                        break;
+                                }
+                        }
+                        if ( $all_found ) {
+                                return true;
+                        }
+                        $this->do_sleep( $sleep );
+                } while ( time() <= $deadline );
+
+                return false;
+        }
+
+        /**
+         * Query a resolver for TXT records.
+         *
+         * @param string $name     FQDN to query.
+         * @param string $resolver Resolver address.
+         *
+         * @return array<int, string> List of TXT records.
+         */
+        protected function query_txt( string $name, string $resolver ): array {
+                $cmd = sprintf( 'dig +short @%s TXT %s', escapeshellarg( $resolver ), escapeshellarg( $name ) );
+                $output = array();
+                $status = 1;
+                @exec( $cmd, $output, $status );
+                if ( 0 !== $status ) {
+                        return array();
+                }
+                $records = array();
+                foreach ( $output as $line ) {
+                        $line = trim( $line );
+                        if ( '' === $line ) {
+                                continue;
+                        }
+                        $records[] = trim( $line, '"' );
+                }
+                return $records;
+        }
+
+        /**
+         * Sleep wrapper to allow mocking in tests.
+         *
+         * @param int $seconds Seconds to sleep.
+         */
+        protected function do_sleep( int $seconds ): void {
+                sleep( $seconds );
+        }
+}

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.16
+ * Version:           0.1.17
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.16';
+const PORKPRESS_SSL_VERSION = '0.1.17';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 require_once __DIR__ . '/includes/class-admin.php';
@@ -29,6 +29,7 @@ require_once __DIR__ . '/includes/class-domain-service.php';
 require_once __DIR__ . '/includes/class-ssl-service.php';
 require_once __DIR__ . '/includes/class-logger.php';
 require_once __DIR__ . '/includes/class-reconciler.php';
+require_once __DIR__ . '/includes/class-txt-propagation-waiter.php';
 
 /**
  * Activation hook callback.

--- a/tests/TxtPropagationWaiterTest.php
+++ b/tests/TxtPropagationWaiterTest.php
@@ -1,0 +1,26 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/class-txt-propagation-waiter.php';
+
+class TxtPropagationWaiterTest extends TestCase {
+    public function testWaitReturnsTrueWhenRecordsFound() {
+        $waiter = new class extends \PorkPress\SSL\TXT_Propagation_Waiter {
+            protected function query_txt( string $name, string $resolver ): array {
+                return array( 'token' );
+            }
+            protected function do_sleep( int $seconds ): void {}
+        };
+        $this->assertTrue( $waiter->wait( 'example.com', 'token', 1, 0 ) );
+    }
+
+    public function testWaitTimesOutWhenRecordsMissing() {
+        $waiter = new class extends \PorkPress\SSL\TXT_Propagation_Waiter {
+            protected function query_txt( string $name, string $resolver ): array {
+                return array();
+            }
+            protected function do_sleep( int $seconds ): void {}
+        };
+        $this->assertFalse( $waiter->wait( 'example.com', 'token', 1, 0 ) );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TXT_Propagation_Waiter` to poll multiple DNS resolvers for `_acme-challenge` TXT records until found or timeout
- Test success and timeout behaviors for the propagation waiter
- Bump plugin version to 0.1.17 and load the new utility

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_6898093f8c5c83338326ff762de483f5