### PR TITLE
Add Porkbun DNS TXT management scripts

### DIFF
--- a/bin/porkbun-add-txt.sh
+++ b/bin/porkbun-add-txt.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${PORKBUN_API_KEY:-}" || -z "${PORKBUN_API_SECRET:-}" ]]; then
+  jq -n --arg error "Missing PORKBUN_API_KEY or PORKBUN_API_SECRET" '{error:$error}'
+  exit 1
+fi
+
+domain="${1:?domain required}"
+name="${2:?subdomain required}"
+content="${3:?content required}"
+ttl="${4:-600}"
+
+jq -n --arg action "add_txt" --arg domain "$domain" --arg name "$name" --arg ttl "$ttl" '{action:$action, domain:$domain, name:$name, ttl:$ttl}'
+
+payload=$(jq -n \
+  --arg apikey "$PORKBUN_API_KEY" \
+  --arg secretapikey "$PORKBUN_API_SECRET" \
+  --arg name "$name" \
+  --arg content "$content" \
+  --arg ttl "$ttl" \
+  '{apikey:$apikey, secretapikey:$secretapikey, name:$name, type:"TXT", content:$content, ttl:$ttl}')
+
+response=$(curl -s -X POST "https://api.porkbun.com/api/json/v3/dns/create/$domain" \
+  -H "Content-Type: application/json" \
+  --data "$payload")
+
+echo "$response" | jq --arg action "response" '{action:$action} + .'

--- a/bin/porkbun-del-txt.sh
+++ b/bin/porkbun-del-txt.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${PORKBUN_API_KEY:-}" || -z "${PORKBUN_API_SECRET:-}" ]]; then
+  jq -n --arg error "Missing PORKBUN_API_KEY or PORKBUN_API_SECRET" '{error:$error}'
+  exit 1
+fi
+
+domain="${1:?domain required}"
+name="${2:?subdomain required}"
+
+jq -n --arg action "del_txt" --arg domain "$domain" --arg name "$name" '{action:$action, domain:$domain, name:$name}'
+
+payload=$(jq -n \
+  --arg apikey "$PORKBUN_API_KEY" \
+  --arg secretapikey "$PORKBUN_API_SECRET" \
+  '{apikey:$apikey, secretapikey:$secretapikey}')
+
+response=$(curl -s -X POST "https://api.porkbun.com/api/json/v3/dns/deleteByNameType/$domain/TXT/$name" \
+  -H "Content-Type: application/json" \
+  --data "$payload")
+
+echo "$response" | jq --arg action "response" '{action:$action} + .'

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.17
+ * Version:           0.1.18
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true


### PR DESCRIPTION
## Summary
- add helper scripts for creating and deleting TXT records through the Porkbun API, reading credentials from the environment and honoring TTL
- bump plugin version to 0.1.18

## Testing
- `phpunit tests`
- `shellcheck -f json bin/porkbun-add-txt.sh bin/porkbun-del-txt.sh`


------
https://chatgpt.com/codex/tasks/task_e_68980c12f8948333b197d7f84803ca85