### PR TITLE
Add WP-CLI SSL management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # PorkPress-SSL
 A wordpress multisite plugin for porkbun that can optionally update certbot for SSL.
+
+## WP-CLI
+
+The plugin exposes commands for managing certificates using Certbot's DNS-01
+challenge. TXT records are created and removed through bundled hook scripts
+for Porkbun.
+
+Issue a certificate for one or more domains:
+
+```
+wp porkpress ssl:issue --domains="a.com,b.com" [--staging] [--cert-name="porkpress-network"]
+```
+
+Renew the certificate for all domains recorded in the manifest:
+
+```
+wp porkpress ssl:renew-all [--staging] [--cert-name="porkpress-network"]
+```
+
+## Certificate and state locations
+
+Certificates are stored under `${PORKPRESS_CERT_ROOT}/live/<cert-name>/` and a
+JSON manifest is written to `${PORKPRESS_STATE_ROOT}/manifest.json` describing
+the active certificate. By default these roots are `/etc/letsencrypt` and
+`/var/lib/porkpress-ssl` respectively. They can be customized in `wp-config.php`:
+
+```
+define('PORKPRESS_CERT_ROOT', '/etc/letsencrypt');
+define('PORKPRESS_STATE_ROOT', '/var/lib/porkpress-ssl');
+```

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * WP-CLI commands for PorkPress SSL.
+ *
+ * @package PorkPress\SSL
+ */
+
+namespace PorkPress\SSL;
+
+use WP_CLI;
+use WP_CLI_Command;
+
+/**
+ * Manage SSL certificates via WP-CLI.
+ */
+class CLI extends WP_CLI_Command {
+        /**
+         * Issue a certificate for a set of domains.
+         *
+         * ## OPTIONS
+         *
+         * --domains=<domains>
+         * : Comma-separated list of domains.
+         *
+         * [--staging]
+         * : Use Let's Encrypt staging environment.
+         *
+         * [--cert-name=<name>]
+         * : Certificate name to use. Defaults to "porkpress-network".
+         *
+         * ## EXAMPLES
+         *
+         *     wp porkpress ssl:issue --domains="example.com,www.example.com"
+         *
+         * @when after_wp_load
+         *
+         * @param array $args       Positional arguments.
+         * @param array $assoc_args Associative arguments.
+         */
+        public function issue( $args, $assoc_args ) {
+                if ( empty( $assoc_args['domains'] ) ) {
+                        WP_CLI::error( '--domains is required.' );
+                }
+                $domains   = array_filter( array_map( 'trim', explode( ',', $assoc_args['domains'] ) ) );
+                $cert_name = $assoc_args['cert-name'] ?? 'porkpress-network';
+                $staging   = isset( $assoc_args['staging'] );
+                $this->run_certbot( $domains, $cert_name, $staging, false );
+        }
+
+        /**
+         * Renew the certificate for all domains in the manifest.
+         *
+         * ## OPTIONS
+         *
+         * [--staging]
+         * : Use Let's Encrypt staging environment.
+         *
+         * [--cert-name=<name>]
+         * : Certificate name to use. Defaults to "porkpress-network".
+         *
+         * ## EXAMPLES
+         *
+         *     wp porkpress ssl:renew-all
+         *
+         * @when after_wp_load
+         *
+         * @param array $args       Positional arguments.
+         * @param array $assoc_args Associative arguments.
+         */
+        public function renew_all( $args, $assoc_args ) {
+                $state_root    = defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl';
+                $manifest_path = rtrim( $state_root, '/\\' ) . '/manifest.json';
+                if ( ! file_exists( $manifest_path ) ) {
+                        WP_CLI::error( 'Manifest not found. Issue a certificate first.' );
+                }
+                $manifest = json_decode( file_get_contents( $manifest_path ), true );
+                if ( empty( $manifest['domains'] ) || ! is_array( $manifest['domains'] ) ) {
+                        WP_CLI::error( 'Manifest does not contain domains.' );
+                }
+                $domains   = $manifest['domains'];
+                $cert_name = $assoc_args['cert-name'] ?? ( $manifest['cert_name'] ?? 'porkpress-network' );
+                $staging   = isset( $assoc_args['staging'] );
+                $this->run_certbot( $domains, $cert_name, $staging, true );
+        }
+
+        /**
+         * Invoke certbot and write manifest.
+         *
+         * @param array  $domains    Domains to include.
+         * @param string $cert_name  Certificate lineage name.
+         * @param bool   $staging    Whether to use staging environment.
+         * @param bool   $renewal    Force renewal of existing certificate.
+         */
+        protected function run_certbot( array $domains, string $cert_name, bool $staging, bool $renewal ) {
+                $cert_root  = defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt';
+                $state_root = defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl';
+
+                if ( ! is_dir( $state_root ) ) {
+                        wp_mkdir_p( $state_root );
+                }
+                if ( ! is_dir( $cert_root ) ) {
+                        wp_mkdir_p( $cert_root );
+                }
+
+                $auth_hook    = dirname( __DIR__ ) . '/bin/porkbun-add-txt.sh';
+                $cleanup_hook = dirname( __DIR__ ) . '/bin/porkbun-del-txt.sh';
+
+                $cmd = 'certbot certonly --manual --non-interactive --agree-tos --manual-public-ip-logging-ok --preferred-challenges dns';
+                $cmd .= ' --manual-auth-hook ' . escapeshellarg( $auth_hook );
+                $cmd .= ' --manual-cleanup-hook ' . escapeshellarg( $cleanup_hook );
+                $cmd .= ' --cert-name ' . escapeshellarg( $cert_name );
+                $cmd .= ' --config-dir ' . escapeshellarg( $cert_root );
+                $cmd .= ' --work-dir ' . escapeshellarg( $state_root );
+                $cmd .= ' --logs-dir ' . escapeshellarg( $state_root );
+                if ( $renewal ) {
+                        $cmd .= ' --force-renewal';
+                }
+                if ( $staging ) {
+                        $cmd .= ' --test-cert';
+                }
+                foreach ( $domains as $domain ) {
+                        $cmd .= ' -d ' . escapeshellarg( $domain );
+                }
+
+                $result = WP_CLI::launch( $cmd, false, true );
+                if ( 0 !== $result->return_code ) {
+                        WP_CLI::error( 'certbot failed: ' . $result->stderr );
+                }
+
+                $live_dir = rtrim( $cert_root, '/\\' ) . '/live/' . $cert_name;
+                $paths    = [
+                        'fullchain' => $live_dir . '/fullchain.pem',
+                        'privkey'   => $live_dir . '/privkey.pem',
+                        'chain'     => $live_dir . '/chain.pem',
+                        'cert'      => $live_dir . '/cert.pem',
+                ];
+
+                $issued_at = $expires_at = null;
+                if ( file_exists( $paths['cert'] ) ) {
+                        $cert_data = openssl_x509_parse( file_get_contents( $paths['cert'] ) );
+                        if ( $cert_data ) {
+                                $issued_at  = gmdate( 'c', $cert_data['validFrom_time_t'] );
+                                $expires_at = gmdate( 'c', $cert_data['validTo_time_t'] );
+                        }
+                }
+
+                $manifest = [
+                        'cert_name'  => $cert_name,
+                        'domains'    => array_values( $domains ),
+                        'issued_at'  => $issued_at,
+                        'expires_at' => $expires_at,
+                        'paths'      => $paths,
+                ];
+
+                file_put_contents( rtrim( $state_root, '/\\' ) . '/manifest.json', wp_json_encode( $manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+
+                WP_CLI::success( 'Certificate stored.' );
+        }
+}

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.18
+ * Version:           0.1.19
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,9 +19,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.17';
+const PORKPRESS_SSL_VERSION = '0.1.19';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
+
+if ( ! defined( 'PORKPRESS_CERT_ROOT' ) ) {
+        define( 'PORKPRESS_CERT_ROOT', '/etc/letsencrypt' );
+}
+if ( ! defined( 'PORKPRESS_STATE_ROOT' ) ) {
+        define( 'PORKPRESS_STATE_ROOT', '/var/lib/porkpress-ssl' );
+}
+
 require_once __DIR__ . '/includes/class-admin.php';
 require_once __DIR__ . '/includes/class-porkbun-client.php';
 require_once __DIR__ . '/includes/class-porkbun-client-dryrun.php';
@@ -30,6 +38,11 @@ require_once __DIR__ . '/includes/class-ssl-service.php';
 require_once __DIR__ . '/includes/class-logger.php';
 require_once __DIR__ . '/includes/class-reconciler.php';
 require_once __DIR__ . '/includes/class-txt-propagation-waiter.php';
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+        require_once __DIR__ . '/includes/class-cli.php';
+        \WP_CLI::add_command( 'porkpress ssl', \PorkPress\SSL\CLI::class );
+}
 
 /**
  * Activation hook callback.


### PR DESCRIPTION
## Summary
- add `wp porkpress ssl:issue` and `wp porkpress ssl:renew-all` commands powered by Certbot DNS-01 hooks
- store certs under configurable `PORKPRESS_CERT_ROOT` and write manifest under `PORKPRESS_STATE_ROOT`
- expose root constants in wp-config.php and bump plugin version to 0.1.19

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_68981012c8748333aaeaf74d0e72dd26