### PR TITLE
Queue SSL issuance on alias changes

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -183,6 +183,16 @@ class Admin {
                submit_button( __( 'Reconcile Now', 'porkpress-ssl' ), 'secondary', 'reconcile_now', false );
                echo '</form>';
 
+               if ( isset( $_POST['porkpress_ssl_issue_nonce'] ) && wp_verify_nonce( wp_unslash( $_POST['porkpress_ssl_issue_nonce'] ), 'porkpress_ssl_issue' ) ) {
+                       SSL_Service::run_queue();
+                       echo '<div class="updated"><p>' . esc_html__( 'Issuance tasks processed.', 'porkpress-ssl' ) . '</p></div>';
+               }
+
+               echo '<form method="post" style="margin-bottom:1em;">';
+               wp_nonce_field( 'porkpress_ssl_issue', 'porkpress_ssl_issue_nonce' );
+               submit_button( __( 'Run now', 'porkpress-ssl' ), 'secondary', 'issue_now', false );
+               echo '</form>';
+
                $result = $service->list_domains();
                 if ( $result instanceof Porkbun_Client_Error ) {
                         $message = $result->message;

--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -388,7 +388,14 @@ KEY domain (domain)
                        'status'     => sanitize_text_field( $status ),
                );
 
-               return false !== $wpdb->insert( $table, $data, array( '%d', '%s', '%d', '%s' ) );
+               $result = $wpdb->insert( $table, $data, array( '%d', '%s', '%d', '%s' ) );
+
+               if ( false !== $result ) {
+                       SSL_Service::queue_issuance( $site_id );
+                       return true;
+               }
+
+               return false;
        }
 
        /**
@@ -454,7 +461,7 @@ KEY domain (domain)
                        return false;
                }
 
-               return false !== $wpdb->update(
+               $result = $wpdb->update(
                        self::get_alias_table_name(),
                        $fields,
                        array(
@@ -464,6 +471,13 @@ KEY domain (domain)
                        $formats,
                        array( '%d', '%s' )
                );
+
+               if ( false !== $result ) {
+                       SSL_Service::queue_issuance( $site_id );
+                       return true;
+               }
+
+               return false;
        }
 
        /**
@@ -477,7 +491,7 @@ KEY domain (domain)
        public function delete_alias( int $site_id, string $domain ): bool {
                global $wpdb;
 
-               return false !== $wpdb->delete(
+               $result = $wpdb->delete(
                        self::get_alias_table_name(),
                        array(
                                'site_id' => $site_id,
@@ -485,6 +499,13 @@ KEY domain (domain)
                        ),
                        array( '%d', '%s' )
                );
+
+               if ( false !== $result ) {
+                       SSL_Service::queue_issuance( $site_id );
+                       return true;
+               }
+
+               return false;
        }
 
        /**

--- a/includes/class-ssl-service.php
+++ b/includes/class-ssl-service.php
@@ -11,7 +11,97 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Class SSL_Service
+ *
+ * Basic queuing and execution of SSL certificate issuance tasks. Issuance is
+ * represented by logging the domains that would be included in the SAN
+ * certificate. The queue is stored as a site option when WordPress functions
+ * are available. In testing environments without WordPress, a static property
+ * is used as a fallback.
  */
 class SSL_Service {
-	// Placeholder for SSL certificate management.
+       /**
+        * Fallback queue used when WordPress option functions are unavailable.
+        *
+        * @var array<int>
+        */
+       protected static array $fallback_queue = array();
+
+       /**
+        * Queue a site for SSL certificate issuance.
+        *
+        * @param int $site_id Site ID.
+        */
+       public static function queue_issuance( int $site_id ): void {
+               $site_id = (int) $site_id;
+
+               if ( function_exists( '\\get_site_option' ) && function_exists( '\\update_site_option' ) ) {
+                       $queue = \get_site_option( 'porkpress_ssl_issuance_queue', array() );
+                       if ( ! in_array( $site_id, $queue, true ) ) {
+                               $queue[] = $site_id;
+                               \update_site_option( 'porkpress_ssl_issuance_queue', $queue );
+                       }
+
+                       if ( function_exists( '\\wp_next_scheduled' ) && function_exists( '\\wp_schedule_single_event' ) ) {
+                               if ( ! \wp_next_scheduled( 'porkpress_ssl_run_issuance' ) ) {
+                                       \wp_schedule_single_event( time(), 'porkpress_ssl_run_issuance' );
+                               }
+                       }
+
+                       return;
+               }
+
+               if ( ! in_array( $site_id, self::$fallback_queue, true ) ) {
+                       self::$fallback_queue[] = $site_id;
+               }
+       }
+
+       /**
+        * Retrieve the queued site IDs.
+        *
+        * @return array<int>
+        */
+       public static function get_queue(): array {
+               if ( function_exists( '\\get_site_option' ) && function_exists( '\\update_site_option' ) ) {
+                       $queue = \get_site_option( 'porkpress_ssl_issuance_queue', array() );
+                       return array_map( 'intval', $queue );
+               }
+
+               return array_map( 'intval', self::$fallback_queue );
+       }
+
+       /**
+        * Clear the issuance queue.
+        */
+       public static function clear_queue(): void {
+               if ( function_exists( '\\get_site_option' ) && function_exists( '\\update_site_option' ) ) {
+                       \update_site_option( 'porkpress_ssl_issuance_queue', array() );
+               }
+               self::$fallback_queue = array();
+       }
+
+       /**
+        * Execute the issuance queue.
+        *
+        * @param Domain_Service|null $domains Optional domain service instance.
+        */
+       public static function run_queue( ?Domain_Service $domains = null ): void {
+               $domains = $domains ?: new Domain_Service();
+
+               foreach ( self::get_queue() as $site_id ) {
+                       $aliases = $domains->get_aliases( $site_id );
+                       $names   = array_map( fn( $a ) => $a['domain'], $aliases );
+
+                       Logger::info(
+                               'issue_certificate',
+                               array(
+                                       'site_id' => $site_id,
+                                       'domains' => $names,
+                               ),
+                               'queued'
+                       );
+               }
+
+               self::clear_queue();
+       }
 }
+

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.19
+ * Version:           0.1.20
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.19';
+const PORKPRESS_SSL_VERSION = '0.1.20';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 
@@ -144,6 +144,8 @@ add_action( 'porkpress_ssl_reconcile', function () {
                );
        }
 } );
+
+add_action( 'porkpress_ssl_run_issuance', array( '\\PorkPress\\SSL\\SSL_Service', 'run_queue' ) );
 
 /**
  * Map meta capabilities for the plugin.

--- a/tests/SSLServiceTest.php
+++ b/tests/SSLServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! function_exists( 'get_site_option' ) ) {
+    $GLOBALS['porkpress_site_options'] = array();
+    function get_site_option( $key, $default = array() ) {
+        return $GLOBALS['porkpress_site_options'][ $key ] ?? $default;
+    }
+    function update_site_option( $key, $value ) {
+        $GLOBALS['porkpress_site_options'][ $key ] = $value;
+    }
+}
+
+if ( ! function_exists( 'wp_next_scheduled' ) ) {
+    function wp_next_scheduled( $hook ) {
+        return false;
+    }
+}
+
+if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+    function wp_schedule_single_event( $timestamp, $hook ) {
+        $GLOBALS['porkpress_scheduled'][] = $hook;
+    }
+}
+
+if ( ! function_exists( 'current_time' ) ) {
+    function current_time( $type ) {
+        return gmdate( 'Y-m-d H:i:s' );
+    }
+}
+
+if ( ! function_exists( 'get_current_user_id' ) ) {
+    function get_current_user_id() {
+        return 0;
+    }
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+    function wp_json_encode( $data ) {
+        return json_encode( $data );
+    }
+}
+
+class DummyWpdb {
+    public $base_prefix = 'wp_';
+    public function insert( $table, $data, $format = null ) {}
+}
+
+require_once __DIR__ . '/../includes/class-ssl-service.php';
+require_once __DIR__ . '/../includes/class-domain-service.php';
+require_once __DIR__ . '/../includes/class-logger.php';
+
+class SSLServiceTest extends TestCase {
+    protected function setUp(): void {
+        global $wpdb;
+        $wpdb = new DummyWpdb();
+    }
+
+    public function testQueueAndRun() {
+        \PorkPress\SSL\SSL_Service::clear_queue();
+        \PorkPress\SSL\SSL_Service::queue_issuance( 1 );
+        \PorkPress\SSL\SSL_Service::queue_issuance( 2 );
+
+        $this->assertSame( [ 1, 2 ], \PorkPress\SSL\SSL_Service::get_queue() );
+
+        $domains = new class extends \PorkPress\SSL\Domain_Service {
+            public array $seen = array();
+            public function __construct() {}
+            public function get_aliases( ?int $site_id = null, ?string $domain = null ): array {
+                $this->seen[] = $site_id;
+                return array( array( 'domain' => 'example.com' ) );
+            }
+        };
+
+        \PorkPress\SSL\SSL_Service::run_queue( $domains );
+
+        $this->assertSame( [ 1, 2 ], $domains->seen );
+        $this->assertSame( [], \PorkPress\SSL\SSL_Service::get_queue() );
+    }
+}


### PR DESCRIPTION
## Summary
- queue SSL issuance tasks when domain aliases are added, updated, or removed
- expose a "Run now" action on the Domains admin page to process queued certificates
- increment plugin version to 0.1.20 and wire issuance cron hook

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_6898134bc7388333bbab1da5a559b8f6