### PR TITLE
Add notification system with expiry warnings

### DIFF
--- a/includes/class-notifier.php
+++ b/includes/class-notifier.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Notification helper.
+ *
+ * @package PorkPress\SSL
+ */
+
+namespace PorkPress\SSL;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Sends email and admin notices for plugin events.
+ */
+class Notifier {
+/** Option key for stored notices. */
+public const OPTION = 'porkpress_ssl_notices';
+
+/**
+ * Send a notification and store an admin notice.
+ *
+ * @param string $type    Notice type (success|error|warning).
+ * @param string $subject Email subject.
+ * @param string $message Message body.
+ */
+public static function notify( string $type, string $subject, string $message ): void {
+$logs_url    = \network_admin_url( 'admin.php?page=porkpress-ssl&tab=logs' );
+$domains_url = \network_admin_url( 'admin.php?page=porkpress-ssl&tab=domains' );
+
+$notice  = $message;
+$notice .= sprintf(
+' <a href="%s">%s</a> | <a href="%s">%s</a>',
+\esc_url( $logs_url ),
+\esc_html__( 'View logs', 'porkpress-ssl' ),
+\esc_url( $domains_url ),
+\esc_html__( 'Reconcile now', 'porkpress-ssl' )
+);
+
+$notices   = \get_site_option( self::OPTION, array() );
+$notices[] = array(
+'type'    => $type,
+'message' => $notice,
+);
+\update_site_option( self::OPTION, $notices );
+
+$email = \get_site_option( 'admin_email' );
+if ( $email ) {
+$body = $message . "\n\n" . sprintf(
+"%s: %s\n%s: %s",
+\__( 'View logs', 'porkpress-ssl' ),
+$logs_url,
+\__( 'Reconcile now', 'porkpress-ssl' ),
+$domains_url
+);
+\wp_mail( $email, $subject, $body );
+}
+}
+
+/** Register admin notice hooks. */
+public static function register(): void {
+\add_action( 'admin_notices', array( __CLASS__, 'display' ) );
+\add_action( 'network_admin_notices', array( __CLASS__, 'display' ) );
+}
+
+/**
+ * Display stored admin notices.
+ */
+public static function display(): void {
+if ( ! \current_user_can( 'manage_network' ) ) {
+return;
+}
+$notices = \get_site_option( self::OPTION, array() );
+if ( empty( $notices ) ) {
+return;
+}
+foreach ( $notices as $notice ) {
+printf(
+'<div class="notice notice-%1$s is-dismissible"><p>%2$s</p></div>',
+\esc_attr( $notice['type'] ),
+\wp_kses_post( $notice['message'] )
+);
+}
+\delete_site_option( self::OPTION );
+}
+}

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.21
+ * Version:           0.1.22
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.21';
+const PORKPRESS_SSL_VERSION = '0.1.22';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 
@@ -39,6 +39,7 @@ require_once __DIR__ . '/includes/class-logger.php';
 require_once __DIR__ . '/includes/class-reconciler.php';
 require_once __DIR__ . '/includes/class-txt-propagation-waiter.php';
 require_once __DIR__ . '/includes/class-renewal-service.php';
+require_once __DIR__ . '/includes/class-notifier.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
         require_once __DIR__ . '/includes/class-cli.php';
@@ -123,6 +124,7 @@ function porkpress_ssl_init() {
 
        $admin = new \PorkPress\SSL\Admin();
       $admin->init();
+      \PorkPress\SSL\Notifier::register();
       \PorkPress\SSL\Renewal_Service::maybe_schedule();
 
       if ( is_network_admin() && isset( $_GET['page'] ) && 'porkpress-ssl' === $_GET['page'] ) {

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -1,0 +1,51 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class NotifierTest extends TestCase {
+    protected function setUp(): void {
+        if ( ! defined( 'ABSPATH' ) ) {
+            define( 'ABSPATH', __DIR__ );
+        }
+
+        $GLOBALS['porkpress_site_options'] = array( 'admin_email' => 'admin@example.com' );
+        $GLOBALS['porkpress_emails']       = array();
+
+        function get_site_option( $key, $default = array() ) {
+            return $GLOBALS['porkpress_site_options'][ $key ] ?? $default;
+        }
+        function update_site_option( $key, $value ) {
+            $GLOBALS['porkpress_site_options'][ $key ] = $value;
+        }
+        function delete_site_option( $key ) {
+            unset( $GLOBALS['porkpress_site_options'][ $key ] );
+        }
+        function network_admin_url( $path = '' ) {
+            return 'https://example.com/' . $path;
+        }
+        function wp_mail( $to, $subject, $message ) {
+            $GLOBALS['porkpress_emails'][] = compact( 'to', 'subject', 'message' );
+            return true;
+        }
+        function add_action( $hook, $callback ) {}
+        function current_user_can( $cap ) { return true; }
+        function __( $text, $domain = null ) { return $text; }
+        function esc_html__( $text, $domain = null ) { return $text; }
+        function esc_url( $url ) { return $url; }
+        function esc_attr( $text ) { return $text; }
+        function wp_kses_post( $text ) { return $text; }
+
+        require_once __DIR__ . '/../includes/class-notifier.php';
+    }
+
+    public function testNotifyStoresNoticeAndEmail() {
+        \PorkPress\SSL\Notifier::notify( 'success', 'Subject', 'Body' );
+        $notices = get_site_option( \PorkPress\SSL\Notifier::OPTION );
+        $this->assertCount( 1, $notices );
+        $this->assertSame( 'success', $notices[0]['type'] );
+        $this->assertStringContainsString( 'View logs', $notices[0]['message'] );
+        $this->assertNotEmpty( $GLOBALS['porkpress_emails'] );
+    }
+}

--- a/tests/RenewalServiceTest.php
+++ b/tests/RenewalServiceTest.php
@@ -21,6 +21,7 @@ class RenewalServiceTest extends TestCase {
 
         function get_site_option($key, $default = null){ return $GLOBALS['porkpress_site_options'][$key] ?? $default; }
         function update_site_option($key, $value){ $GLOBALS['porkpress_site_options'][$key] = $value; }
+        function delete_site_option($key){ unset($GLOBALS['porkpress_site_options'][$key]); }
         function wp_next_scheduled($hook){ return $GLOBALS['porkpress_events'][$hook] ?? false; }
         function wp_schedule_single_event($timestamp, $hook){ $GLOBALS['porkpress_events'][$hook] = $timestamp; $GLOBALS['porkpress_scheduled'][] = $hook; }
         function wp_unschedule_event($timestamp, $hook){ unset($GLOBALS['porkpress_events'][$hook]); }
@@ -28,10 +29,20 @@ class RenewalServiceTest extends TestCase {
         function wp_mkdir_p($dir){ if(!is_dir($dir)) mkdir($dir,0777,true); }
         function current_time($t){ return gmdate('Y-m-d H:i:s'); }
         function get_current_user_id(){ return 0; }
+        function network_admin_url($p=''){ return 'https://example.com/'.$p; }
+        function esc_url($u){ return $u; }
+        function esc_html__($t,$d=null){ return $t; }
+        function esc_attr($t){ return $t; }
+        function wp_kses_post($t){ return $t; }
+        function add_action($h,$c){}
+        function current_user_can($c){ return true; }
+        function __($t,$d=null){ return $t; }
+        function wp_mail($to,$sub,$msg){ $GLOBALS['porkpress_mails'][] = compact('to','sub','msg'); }
 
         $GLOBALS['wpdb'] = new class { public $base_prefix = 'wp_'; public function insert($t,$d,$f=null){} };
 
         require_once __DIR__ . '/../includes/class-logger.php';
+        require_once __DIR__ . '/../includes/class-notifier.php';
         require_once __DIR__ . '/../includes/class-renewal-service.php';
 
         $root = sys_get_temp_dir() . '/porkpress-test';


### PR DESCRIPTION
## Summary
- add Notifier class to send email and admin notices linking to logs and "Reconcile now"
- alert on certificate success, failure, and upcoming expiry
- bump plugin version to 0.1.22 and register notifier

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_6898acaa7e1c83338848f44a43b61f71