### PR TITLE
Add dashboard metrics and bump version

### DIFF
--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.22
+ * Version:           0.1.23
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.22';
+const PORKPRESS_SSL_VERSION = '0.1.23';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 


### PR DESCRIPTION
## Summary
- show network dashboard cards for Porkbun and mapping stats
- report last SSL issuance run and reconcile status
- bump plugin version to 0.1.23

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_6898b08716d08333ba4be3bbbb838a8f