### PR TITLE
Add export options for logs and domain mapping

### DIFF
--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -134,4 +134,33 @@ $sql = $wpdb->prepare( $sql, $params );
 
 return $wpdb->get_results( $sql, ARRAY_A );
 }
+
+/**
+ * Redact sensitive fields from a context JSON string.
+ *
+ * @param string $context_json JSON-encoded context.
+ * @param bool   $encode       Whether to return JSON string. If false, returns array.
+ *
+ * @return string|array
+ */
+public static function sanitize_context( string $context_json, bool $encode = true ) {
+$data = json_decode( $context_json, true );
+if ( ! is_array( $data ) ) {
+return $encode ? $context_json : $data;
+}
+
+$secrets = array( 'api_key', 'api_secret', 'key', 'secret', 'password' );
+foreach ( $secrets as $secret ) {
+if ( array_key_exists( $secret, $data ) ) {
+unset( $data[ $secret ] );
+}
+}
+
+if ( ! $encode ) {
+return $data;
+}
+
+$encode_fn = function_exists( 'wp_json_encode' ) ? 'wp_json_encode' : 'json_encode';
+return $encode_fn( $data );
+}
 }

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.1.23
+ * Version:           0.1.24
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.1.23';
+const PORKPRESS_SSL_VERSION = '0.1.24';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -1,0 +1,19 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ );
+}
+
+require_once __DIR__ . '/../includes/class-logger.php';
+
+class LoggerTest extends TestCase {
+    public function test_sanitize_context_removes_secrets() {
+        $ctx = json_encode( array( 'foo' => 'bar', 'api_key' => 'secret', 'password' => 'p' ) );
+        $sanitized = \PorkPress\SSL\Logger::sanitize_context( $ctx );
+        $data = json_decode( $sanitized, true );
+        $this->assertSame( 'bar', $data['foo'] );
+        $this->assertArrayNotHasKey( 'api_key', $data );
+        $this->assertArrayNotHasKey( 'password', $data );
+    }
+}


### PR DESCRIPTION
## Summary
- allow exporting logs as CSV or JSON while redacting secret fields
- add CSV/JSON export of domain alias mapping
- expose `export-logs` and `export-mapping` WP-CLI commands
- bump plugin version to 0.1.24

## Testing
- `php -l includes/class-logger.php`
- `php -l includes/class-admin.php`
- `php -l includes/class-cli.php`
- `php -l porkpress-ssl.php`
- `php -l tests/LoggerTest.php`
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_6898b36fa040833383760271831c1039