### PR TITLE
Improve TXT propagation waiter error handling and configurability

### DIFF
--- a/includes/class-txt-propagation-waiter.php
+++ b/includes/class-txt-propagation-waiter.php
@@ -27,7 +27,15 @@ class TXT_Propagation_Waiter {
          *
          * @param array<int, string> $resolvers Resolver IPs.
          */
-        public function __construct( array $resolvers = array( '8.8.8.8', '1.1.1.1' ) ) {
+        public function __construct( array $resolvers = array() ) {
+                if ( empty( $resolvers ) ) {
+                        $resolvers = array( '8.8.8.8', '1.1.1.1' );
+                }
+
+                if ( function_exists( 'apply_filters' ) ) {
+                        $resolvers = apply_filters( 'porkpress_ssl_txt_propagation_resolvers', $resolvers );
+                }
+
                 $this->resolvers = $resolvers;
         }
 
@@ -82,8 +90,10 @@ class TXT_Propagation_Waiter {
                 $cmd = sprintf( 'dig +short @%s TXT %s', escapeshellarg( $resolver ), escapeshellarg( $name ) );
                 $output = array();
                 $status = 1;
-                @exec( $cmd, $output, $status );
+                exec( $cmd, $output, $status );
                 if ( 0 !== $status ) {
+                        $message = sprintf( 'dig command failed for resolver %s (exit code %d)', $resolver, $status );
+                        trigger_error( $message, E_USER_WARNING );
                         return array();
                 }
                 $records = array();

--- a/tests/TxtPropagationWaiterTest.php
+++ b/tests/TxtPropagationWaiterTest.php
@@ -1,9 +1,28 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+    function apply_filters( $tag, $value ) {
+        if ( 'porkpress_ssl_txt_propagation_resolvers' === $tag ) {
+            global $porkpress_txt_resolver_filter;
+            if ( isset( $porkpress_txt_resolver_filter ) ) {
+                return $porkpress_txt_resolver_filter;
+            }
+        }
+        return $value;
+    }
+}
+
 require_once __DIR__ . '/../includes/class-txt-propagation-waiter.php';
 
 class TxtPropagationWaiterTest extends TestCase {
+    protected function tearDown(): void {
+        unset( $GLOBALS['porkpress_txt_resolver_filter'] );
+    }
     public function testWaitReturnsTrueWhenRecordsFound() {
         $waiter = new class extends \PorkPress\SSL\TXT_Propagation_Waiter {
             protected function query_txt( string $name, string $resolver ): array {
@@ -22,5 +41,13 @@ class TxtPropagationWaiterTest extends TestCase {
             protected function do_sleep( int $seconds ): void {}
         };
         $this->assertFalse( $waiter->wait( 'example.com', 'token', 1, 0 ) );
+    }
+
+    public function testResolversFilterApplied() {
+        $GLOBALS['porkpress_txt_resolver_filter'] = array( '9.9.9.9' );
+        $waiter = new class extends \PorkPress\SSL\TXT_Propagation_Waiter {
+            public function get_resolvers() { return $this->resolvers; }
+        };
+        $this->assertSame( array( '9.9.9.9' ), $waiter->get_resolvers() );
     }
 }


### PR DESCRIPTION
## Summary
- allow customizing DNS resolvers via `porkpress_ssl_txt_propagation_resolvers` filter
- warn when `dig` command fails instead of silently suppressing errors
- add tests for resolver filtering and ensure ABSPATH defined

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_6898fc67de3c8333b11ff4cd28178588