### PR TITLE
Sanitize log context before insert

### DIFF
--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -58,18 +58,21 @@ dbDelta( $sql );
  * @param string $severity Log severity.
  */
 public static function log( $action, $context = array(), $result = '', $severity = 'info' ) {
-global $wpdb;
-$wpdb->insert(
-self::get_table_name(),
-array(
-'time'     => current_time( 'mysql' ),
-'user_id'  => get_current_user_id(),
-'action'   => $action,
-'context'  => wp_json_encode( $context ),
-'result'   => $result,
-'severity' => $severity,
-)
-);
+    global $wpdb;
+
+    $context = self::sanitize_context( wp_json_encode( $context ), false );
+
+    $wpdb->insert(
+        self::get_table_name(),
+        array(
+            'time'     => current_time( 'mysql' ),
+            'user_id'  => get_current_user_id(),
+            'action'   => $action,
+            'context'  => wp_json_encode( $context ),
+            'result'   => $result,
+            'severity' => $severity,
+        )
+    );
 }
 
 /**

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -4,6 +4,31 @@ use PHPUnit\Framework\TestCase;
 if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', __DIR__ );
 }
+if ( ! function_exists( 'current_time' ) ) {
+    function current_time( $type ) {
+        return '2023-01-01 00:00:00';
+    }
+}
+if ( ! function_exists( 'get_current_user_id' ) ) {
+    function get_current_user_id() {
+        return 1;
+    }
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+    function wp_json_encode( $data ) {
+        return json_encode( $data );
+    }
+}
+
+class LoggerMockWpdb {
+    public $data = array();
+    public $base_prefix = 'wp_';
+
+    public function insert( $table, $data, $format = null ) {
+        $this->data[ $table ][] = $data;
+        return 1;
+    }
+}
 
 require_once __DIR__ . '/../includes/class-logger.php';
 
@@ -15,5 +40,20 @@ class LoggerTest extends TestCase {
         $this->assertSame( 'bar', $data['foo'] );
         $this->assertArrayNotHasKey( 'api_key', $data );
         $this->assertArrayNotHasKey( 'password', $data );
+    }
+
+    public function test_log_redacts_secrets() {
+        global $wpdb;
+        $wpdb = new LoggerMockWpdb();
+
+        \PorkPress\SSL\Logger::log( 'action', array( 'foo' => 'bar', 'api_key' => 'secret', 'password' => 'p' ) );
+
+        $table = \PorkPress\SSL\Logger::get_table_name();
+        $row   = $wpdb->data[ $table ][0];
+        $ctx   = json_decode( $row['context'], true );
+
+        $this->assertSame( 'bar', $ctx['foo'] );
+        $this->assertArrayNotHasKey( 'api_key', $ctx );
+        $this->assertArrayNotHasKey( 'password', $ctx );
     }
 }


### PR DESCRIPTION
## Summary
- sanitize log context to remove sensitive fields before database insertion
- test that log entries do not store secret keys or passwords

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_6898fc7725f88333a1c50880b6ac5884