### PR TITLE
Add GitHub Actions workflow for PHPUnit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['8.1']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: phpunit
+      - name: Install dependencies
+        run: |
+          if [ -f composer.json ]; then
+            composer install --prefer-dist --no-progress --no-suggest
+          fi
+      - name: Run tests
+        run: phpunit tests


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run PHPUnit tests on push and PR using PHP 8.1

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_6898fc79d7ac83339ccdc76ad26011d6