### PR TITLE
Handle multisite lifecycle events

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,10 @@ the active certificate. By default these roots are `/etc/letsencrypt` and
 define('PORKPRESS_CERT_ROOT', '/etc/letsencrypt');
 define('PORKPRESS_STATE_ROOT', '/var/lib/porkpress-ssl');
 ```
+
+## Multisite lifecycle
+
+PorkPress SSL listens for WordPress multisite events and updates its domain
+alias table automatically. When a site is created, deleted, archived or
+restored the plugin adjusts aliases and queues certificate issuance so SSL
+coverage remains in sync with the network.

--- a/tests/NetworkEventsTest.php
+++ b/tests/NetworkEventsTest.php
@@ -1,0 +1,79 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ );
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $str ) {
+        return $str;
+    }
+}
+if ( ! function_exists( 'add_action' ) ) {
+    function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+    function add_filter( ...$args ) {}
+}
+if ( ! function_exists( 'register_activation_hook' ) ) {
+    function register_activation_hook( ...$args ) {}
+}
+if ( ! function_exists( 'register_deactivation_hook' ) ) {
+    function register_deactivation_hook( ...$args ) {}
+}
+if ( ! function_exists( 'get_site_option' ) ) {
+    $GLOBALS['porkpress_site_options'] = array();
+    function get_site_option( $key, $default = array() ) {
+        return $GLOBALS['porkpress_site_options'][ $key ] ?? $default;
+    }
+    function update_site_option( $key, $value ) {
+        $GLOBALS['porkpress_site_options'][ $key ] = $value;
+    }
+}
+if ( ! function_exists( 'wp_next_scheduled' ) ) {
+    function wp_next_scheduled( $hook ) {
+        return false;
+    }
+}
+if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+    function wp_schedule_single_event( $timestamp, $hook ) {
+        $GLOBALS['porkpress_scheduled'][] = $hook;
+    }
+}
+if ( ! defined( 'ARRAY_A' ) ) {
+    define( 'ARRAY_A', 'ARRAY_A' );
+}
+
+require_once __DIR__ . '/DomainServiceTest.php'; // Provides MockWpdb and includes Domain_Service.
+require_once __DIR__ . '/../porkpress-ssl.php';
+
+class NetworkEventsTest extends TestCase {
+    protected $service;
+
+    protected function setUp(): void {
+        global $wpdb;
+        $wpdb = new MockWpdb();
+        $this->service = new class extends \PorkPress\SSL\Domain_Service {
+            public function __construct() {}
+        };
+    }
+
+    public function testArchiveAndRestore() {
+        $this->service->add_alias( 1, 'example.com', true, 'active' );
+
+        porkpress_ssl_handle_archive_blog( 1 );
+        $alias = $this->service->get_aliases( 1 )[0];
+        $this->assertSame( 'archived', $alias['status'] );
+
+        porkpress_ssl_handle_unarchive_blog( 1 );
+        $alias = $this->service->get_aliases( 1 )[0];
+        $this->assertSame( 'active', $alias['status'] );
+    }
+
+    public function testDeleteRemovesAliases() {
+        $this->service->add_alias( 1, 'example.com', true, 'active' );
+
+        porkpress_ssl_handle_delete_blog( 1, true );
+        $this->assertCount( 0, $this->service->get_aliases( 1 ) );
+    }
+}


### PR DESCRIPTION
## Summary
- register hooks for site create/delete/archive/unarchive events
- update domain alias table via Domain_Service and queue SSL issuance
- document multisite lifecycle behavior and add unit tests

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_68991cf36e888333a5d0cf4b57bbdb8e