### PR TITLE
Add certbot issuance pipeline to SSL_Service

### DIFF
--- a/includes/class-renewal-service.php
+++ b/includes/class-renewal-service.php
@@ -166,7 +166,7 @@ return $cmd;
  * @param array  $domains   Domains included.
  * @param string $cert_name Certificate name.
  */
-protected static function write_manifest( array $domains, string $cert_name ): void {
+public static function write_manifest( array $domains, string $cert_name ): void {
 $cert_root  = defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt';
 $state_root = defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl';
 $live_dir = rtrim( $cert_root, '/\\' ) . '/live/' . $cert_name;


### PR DESCRIPTION
## Summary
- Expand `SSL_Service::run_queue` to issue certificates for queued domains using certbot and send notifications
- Expose `Renewal_Service::write_manifest` for reuse
- Test SSL issuance pipeline and manifest updates

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689923bff0408333acfba16f54d742d2