### PR TITLE
Refactor certbot command builder into helper

### DIFF
--- a/includes/class-certbot-helper.php
+++ b/includes/class-certbot-helper.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Helper utilities for building certbot commands.
+ *
+ * @package PorkPress\SSL
+ */
+
+namespace PorkPress\SSL;
+
+/**
+ * Utility class for constructing certbot command strings.
+ */
+class Certbot_Helper {
+    /**
+     * Build the certbot command.
+     *
+     * @param array  $domains  Domains to include.
+     * @param string $cert_name Certificate lineage name.
+     * @param bool   $staging  Whether to use staging.
+     * @param bool   $renewal  Force renewal.
+     * @return string
+     */
+    public static function build_command( array $domains, string $cert_name, bool $staging, bool $renewal = false ): string {
+        $cert_root  = defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt';
+        $state_root = defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl';
+        $auth_hook    = dirname( __DIR__ ) . '/bin/porkbun-add-txt.sh';
+        $cleanup_hook = dirname( __DIR__ ) . '/bin/porkbun-del-txt.sh';
+        $cmd = 'certbot certonly --manual --non-interactive --agree-tos --manual-public-ip-logging-ok --preferred-challenges dns';
+        $cmd .= ' --manual-auth-hook ' . escapeshellarg( $auth_hook );
+        $cmd .= ' --manual-cleanup-hook ' . escapeshellarg( $cleanup_hook );
+        $cmd .= ' --cert-name ' . escapeshellarg( $cert_name );
+        $cmd .= ' --config-dir ' . escapeshellarg( $cert_root );
+        $cmd .= ' --work-dir ' . escapeshellarg( $state_root );
+        $cmd .= ' --logs-dir ' . escapeshellarg( $state_root );
+        if ( $renewal ) {
+            $cmd .= ' --force-renewal';
+        }
+        if ( $staging ) {
+            $cmd .= ' --test-cert';
+        }
+        foreach ( $domains as $domain ) {
+            $cmd .= ' -d ' . escapeshellarg( $domain );
+        }
+        return $cmd;
+    }
+}

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -103,25 +103,7 @@ class CLI extends WP_CLI_Command {
                         wp_mkdir_p( $cert_root );
                 }
 
-                $auth_hook    = dirname( __DIR__ ) . '/bin/porkbun-add-txt.sh';
-                $cleanup_hook = dirname( __DIR__ ) . '/bin/porkbun-del-txt.sh';
-
-                $cmd = 'certbot certonly --manual --non-interactive --agree-tos --manual-public-ip-logging-ok --preferred-challenges dns';
-                $cmd .= ' --manual-auth-hook ' . escapeshellarg( $auth_hook );
-                $cmd .= ' --manual-cleanup-hook ' . escapeshellarg( $cleanup_hook );
-                $cmd .= ' --cert-name ' . escapeshellarg( $cert_name );
-                $cmd .= ' --config-dir ' . escapeshellarg( $cert_root );
-                $cmd .= ' --work-dir ' . escapeshellarg( $state_root );
-                $cmd .= ' --logs-dir ' . escapeshellarg( $state_root );
-                if ( $renewal ) {
-                        $cmd .= ' --force-renewal';
-                }
-                if ( $staging ) {
-                        $cmd .= ' --test-cert';
-                }
-                foreach ( $domains as $domain ) {
-                        $cmd .= ' -d ' . escapeshellarg( $domain );
-                }
+                $cmd = Certbot_Helper::build_command( $domains, $cert_name, $staging, $renewal );
 
                 $result = WP_CLI::launch( $cmd, false, true );
                 if ( 0 !== $result->return_code ) {

--- a/includes/class-renewal-service.php
+++ b/includes/class-renewal-service.php
@@ -137,27 +137,7 @@ return array(
  * @return string
  */
 public static function build_certbot_command( array $domains, string $cert_name, bool $staging, bool $renewal = false ): string {
-$cert_root  = defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt';
-$state_root = defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl';
-$auth_hook    = dirname( __DIR__ ) . '/bin/porkbun-add-txt.sh';
-$cleanup_hook = dirname( __DIR__ ) . '/bin/porkbun-del-txt.sh';
-$cmd = 'certbot certonly --manual --non-interactive --agree-tos --manual-public-ip-logging-ok --preferred-challenges dns';
-$cmd .= ' --manual-auth-hook ' . escapeshellarg( $auth_hook );
-$cmd .= ' --manual-cleanup-hook ' . escapeshellarg( $cleanup_hook );
-$cmd .= ' --cert-name ' . escapeshellarg( $cert_name );
-$cmd .= ' --config-dir ' . escapeshellarg( $cert_root );
-$cmd .= ' --work-dir ' . escapeshellarg( $state_root );
-$cmd .= ' --logs-dir ' . escapeshellarg( $state_root );
-if ( $renewal ) {
-$cmd .= ' --force-renewal';
-}
-if ( $staging ) {
-$cmd .= ' --test-cert';
-}
-foreach ( $domains as $domain ) {
-$cmd .= ' -d ' . escapeshellarg( $domain );
-}
-return $cmd;
+return Certbot_Helper::build_command( $domains, $cert_name, $staging, $renewal );
 }
 
 /**

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -38,6 +38,7 @@ require_once __DIR__ . '/includes/class-ssl-service.php';
 require_once __DIR__ . '/includes/class-logger.php';
 require_once __DIR__ . '/includes/class-reconciler.php';
 require_once __DIR__ . '/includes/class-txt-propagation-waiter.php';
+require_once __DIR__ . '/includes/class-certbot-helper.php';
 require_once __DIR__ . '/includes/class-renewal-service.php';
 require_once __DIR__ . '/includes/class-notifier.php';
 

--- a/tests/CertbotHelperTest.php
+++ b/tests/CertbotHelperTest.php
@@ -1,0 +1,18 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class CertbotHelperTest extends TestCase {
+    public function testBuildCommandIncludesFlagsAndDomains() {
+        if ( ! defined( 'ABSPATH' ) ) {
+            define( 'ABSPATH', __DIR__ );
+        }
+        require_once __DIR__ . '/../includes/class-certbot-helper.php';
+
+        $cmd = \PorkPress\SSL\Certbot_Helper::build_command( [ 'example.com', 'www.example.com' ], 'test', true, true );
+
+        $this->assertStringContainsString( '--test-cert', $cmd );
+        $this->assertStringContainsString( '--force-renewal', $cmd );
+        $this->assertStringContainsString( "-d 'example.com'", $cmd );
+        $this->assertStringContainsString( "-d 'www.example.com'", $cmd );
+    }
+}

--- a/tests/RenewalServiceTest.php
+++ b/tests/RenewalServiceTest.php
@@ -43,6 +43,7 @@ class RenewalServiceTest extends TestCase {
 
         require_once __DIR__ . '/../includes/class-logger.php';
         require_once __DIR__ . '/../includes/class-notifier.php';
+        require_once __DIR__ . '/../includes/class-certbot-helper.php';
         require_once __DIR__ . '/../includes/class-renewal-service.php';
 
         $root = sys_get_temp_dir() . '/porkpress-test';

--- a/tests/SSLServiceTest.php
+++ b/tests/SSLServiceTest.php
@@ -75,6 +75,7 @@ require_once __DIR__ . '/../includes/class-ssl-service.php';
 require_once __DIR__ . '/../includes/class-domain-service.php';
 require_once __DIR__ . '/../includes/class-logger.php';
 require_once __DIR__ . '/../includes/class-notifier.php';
+require_once __DIR__ . '/../includes/class-certbot-helper.php';
 require_once __DIR__ . '/../includes/class-renewal-service.php';
 
 /**


### PR DESCRIPTION
## Summary
- extract certbot command construction into new Certbot_Helper::build_command
- call the helper from CLI and Renewal_Service to eliminate duplication
- add unit test for the helper and update existing tests

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68992c75d3348333a59e9635858b04d4