### PR TITLE
Fix paginated listDomains stub in reconciler tests

### DIFF
--- a/tests/ReconcilerTest.php
+++ b/tests/ReconcilerTest.php
@@ -96,6 +96,10 @@ class ReconcilerTest extends TestCase {
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public function __construct() {}
             public function listDomains( int $page = 1, int $per_page = 100 ) {
+                if ( $page > 1 ) {
+                    return array( 'status' => 'SUCCESS', 'domains' => array() );
+                }
+
                 return array(
                     'status'  => 'SUCCESS',
                     'domains' => array(
@@ -146,6 +150,10 @@ class ReconcilerTest extends TestCase {
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public function __construct() {}
             public function listDomains( int $page = 1, int $per_page = 100 ) {
+                if ( $page > 1 ) {
+                    return array( 'status' => 'SUCCESS', 'domains' => array() );
+                }
+
                 return array(
                     'status'  => 'SUCCESS',
                     'domains' => array(


### PR DESCRIPTION
## Summary
- Ensure test client listDomains returns empty domains after first page
- Prevent infinite pagination loops during reconcile tests

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68993c9a672483338cc16a801b8d7fce