### PR TITLE
Notify on missing Porkbun credentials and display status

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ Renew the certificate for all domains recorded in the manifest:
 wp porkpress ssl:renew-all [--staging] [--cert-name="porkpress-network"]
 ```
 
+## Porkbun API credentials
+
+The plugin requires a Porkbun API key and secret to manage domains. They can be
+supplied either through constants in `wp-config.php`:
+
+```
+define('PORKPRESS_API_KEY', 'pk_...');
+define('PORKPRESS_API_SECRET', 'sk_...');
+```
+
+or via the network settings stored in the options `porkpress_ssl_api_key` and
+`porkpress_ssl_api_secret`.
+
 ## Certificate and state locations
 
 Certificates are stored under `${PORKPRESS_CERT_ROOT}/live/<cert-name>/` and a

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -146,28 +146,33 @@ class Admin {
                         }
                 }
 
-                $mapped = count( $service->get_aliases() );
+               $mapped       = count( $service->get_aliases() );
 
-                $reconciler  = new Reconciler( $service );
-                $drift       = $reconciler->reconcile_all( false );
-                $drift_count = count( $drift['missing_aliases'] ) + count( $drift['stray_aliases'] ) + count( $drift['disabled_sites'] );
+               $reconciler   = new Reconciler( $service );
+               $drift        = $reconciler->reconcile_all( false );
+               $drift_count  = count( $drift['missing_aliases'] ) + count( $drift['stray_aliases'] ) + count( $drift['disabled_sites'] );
 
-                global $wpdb;
-                $table          = Logger::get_table_name();
-                $ssl_log        = $wpdb->get_row( $wpdb->prepare( "SELECT time, result FROM {$table} WHERE action = %s ORDER BY time DESC LIMIT 1", 'issue_certificate' ), ARRAY_A );
-                $ssl_status     = $ssl_log ? $ssl_log['time'] . ' (' . $ssl_log['result'] . ')' : __( 'Never', 'porkpress-ssl' );
-                $reconcile_log  = $wpdb->get_row( $wpdb->prepare( "SELECT time, result FROM {$table} WHERE action = %s ORDER BY time DESC LIMIT 1", 'reconcile' ), ARRAY_A );
-                $reconcile_stat = $reconcile_log ? $reconcile_log['time'] . ' (' . $reconcile_log['result'] . ')' : __( 'Never', 'porkpress-ssl' );
+               global $wpdb;
+               $table         = Logger::get_table_name();
+               $ssl_log       = $wpdb->get_row( $wpdb->prepare( "SELECT time, result FROM {$table} WHERE action = %s ORDER BY time DESC LIMIT 1", 'issue_certificate' ), ARRAY_A );
+               $ssl_status    = $ssl_log ? $ssl_log['time'] . ' (' . $ssl_log['result'] . ')' : __( 'Never', 'porkpress-ssl' );
+               $reconcile_log = $wpdb->get_row( $wpdb->prepare( "SELECT time, result FROM {$table} WHERE action = %s ORDER BY time DESC LIMIT 1", 'reconcile' ), ARRAY_A );
+               $reconcile_stat = $reconcile_log ? $reconcile_log['time'] . ' (' . $reconcile_log['result'] . ')' : __( 'Never', 'porkpress-ssl' );
 
-                echo '<div style="display:flex; flex-wrap:wrap; gap:1em;">';
-                $cards = array(
-                        __( 'Total Porkbun Domains', 'porkpress-ssl' )          => number_format_i18n( $total_domains ),
-                        __( 'Mapped Domains', 'porkpress-ssl' )                => number_format_i18n( $mapped ),
-                        __( 'Drift Alerts', 'porkpress-ssl' )                 => number_format_i18n( $drift_count ),
-                        __( 'Upcoming Expiries (≤30 days)', 'porkpress-ssl' ) => number_format_i18n( $upcoming_expiry ),
-                        __( 'Last SSL Run Status', 'porkpress-ssl' )          => $ssl_status,
-                        __( 'Last Reconcile', 'porkpress-ssl' )              => $reconcile_stat,
-                );
+               $cred_status = $service->has_credentials()
+                       ? __( 'Configured', 'porkpress-ssl' )
+                       : __( 'Missing', 'porkpress-ssl' );
+
+               echo '<div style="display:flex; flex-wrap:wrap; gap:1em;">';
+               $cards = array(
+                       __( 'API Credentials', 'porkpress-ssl' )              => $cred_status,
+                       __( 'Total Porkbun Domains', 'porkpress-ssl' )        => number_format_i18n( $total_domains ),
+                       __( 'Mapped Domains', 'porkpress-ssl' )              => number_format_i18n( $mapped ),
+                       __( 'Drift Alerts', 'porkpress-ssl' )               => number_format_i18n( $drift_count ),
+                       __( 'Upcoming Expiries (≤30 days)', 'porkpress-ssl' ) => number_format_i18n( $upcoming_expiry ),
+                       __( 'Last SSL Run Status', 'porkpress-ssl' )        => $ssl_status,
+                       __( 'Last Reconcile', 'porkpress-ssl' )            => $reconcile_stat,
+               );
                 foreach ( $cards as $label => $value ) {
                         echo '<div class="card" style="flex:1 1 200px;"><h2>' . esc_html( $label ) . '</h2><p>' . esc_html( $value ) . '</p></div>';
                 }

--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -56,6 +56,12 @@ private const DOMAIN_LIST_MAX_PAGES = 100;
                $this->missing_credentials = empty( $api_key ) || empty( $api_secret );
                if ( $this->dry_run ) {
                        $this->missing_credentials = false;
+               } elseif ( $this->missing_credentials ) {
+                       Notifier::notify(
+                               'error',
+                               __( 'Porkbun API credentials missing', 'porkpress-ssl' ),
+                               __( 'Add your Porkbun API key and secret in the Settings tab or via constants.', 'porkpress-ssl' )
+                       );
                }
 
                if ( $client ) {


### PR DESCRIPTION
## Summary
- Notify administrators when Porkbun API credentials are absent during domain service initialization
- Show API credential status on the dashboard for quick visibility
- Document required Porkbun API key and secret configuration in the README

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689962bbfe9c8333b4f473abf6828e58