### PR TITLE
Make certificate settings configurable and migrate existing certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ the active certificate. By default these roots are `/etc/letsencrypt` and
 ```
 define('PORKPRESS_CERT_ROOT', '/etc/letsencrypt');
 define('PORKPRESS_STATE_ROOT', '/var/lib/porkpress-ssl');
+define('PORKPRESS_CERT_NAME', 'porkpress-network');
 ```
 
 ## Multisite lifecycle

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -577,6 +577,9 @@ class Admin {
 public function render_settings_tab() {
 $api_key_locked    = defined( 'PORKPRESS_API_KEY' );
 $api_secret_locked = defined( 'PORKPRESS_API_SECRET' );
+$cert_name_locked  = defined( 'PORKPRESS_CERT_NAME' );
+$cert_root_locked  = defined( 'PORKPRESS_CERT_ROOT' );
+$state_root_locked = defined( 'PORKPRESS_STATE_ROOT' );
 
         if ( isset( $_POST['porkpress_ssl_settings_nonce'] ) ) {
             check_admin_referer( 'porkpress_ssl_settings', 'porkpress_ssl_settings_nonce' );
@@ -603,6 +606,20 @@ $raw_txt_interval = isset( $_POST['porkpress_txt_interval'] ) ? absint( wp_unsla
 $txt_interval     = max( 1, $raw_txt_interval );
 update_site_option( 'porkpress_ssl_txt_interval', $txt_interval );
 
+if ( ! $cert_name_locked && isset( $_POST['porkpress_cert_name'] ) ) {
+update_site_option( 'porkpress_ssl_cert_name', sanitize_text_field( wp_unslash( $_POST['porkpress_cert_name'] ) ) );
+}
+if ( ! $cert_root_locked && isset( $_POST['porkpress_cert_root'] ) ) {
+update_site_option( 'porkpress_ssl_cert_root', sanitize_text_field( wp_unslash( $_POST['porkpress_cert_root'] ) ) );
+}
+if ( ! $state_root_locked && isset( $_POST['porkpress_state_root'] ) ) {
+update_site_option( 'porkpress_ssl_state_root', sanitize_text_field( wp_unslash( $_POST['porkpress_state_root'] ) ) );
+}
+
+$cert_name = get_site_option( 'porkpress_ssl_cert_name', defined( 'PORKPRESS_CERT_NAME' ) ? PORKPRESS_CERT_NAME : 'porkpress-network' );
+$cert_root = get_site_option( 'porkpress_ssl_cert_root', defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt' );
+$state_root = get_site_option( 'porkpress_ssl_state_root', defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl' );
+
             $auto_reconcile = isset( $_POST['porkpress_auto_reconcile'] ) ? 1 : 0;
             update_site_option( 'porkpress_ssl_auto_reconcile', $auto_reconcile );
 
@@ -621,6 +638,9 @@ update_site_option( 'porkpress_ssl_txt_interval', $txt_interval );
                     'txt_interval'       => $txt_interval,
                     'auto_reconcile'     => (bool) $auto_reconcile,
                     'dry_run'            => (bool) $dry_run,
+                    'cert_name'          => $cert_name,
+                    'cert_root'          => $cert_root,
+                    'state_root'         => $state_root,
                 ),
                 'Settings saved'
             );
@@ -640,6 +660,9 @@ $staging    = (bool) get_site_option( 'porkpress_ssl_le_staging', 0 );
 $renew_window = absint( get_site_option( 'porkpress_ssl_renew_window', 30 ) );
 $txt_timeout  = max( 1, absint( get_site_option( 'porkpress_ssl_txt_timeout', 600 ) ) );
 $txt_interval = max( 1, absint( get_site_option( 'porkpress_ssl_txt_interval', 30 ) ) );
+$cert_name = $cert_name_locked ? PORKPRESS_CERT_NAME : get_site_option( 'porkpress_ssl_cert_name', defined( 'PORKPRESS_CERT_NAME' ) ? PORKPRESS_CERT_NAME : 'porkpress-network' );
+$cert_root = $cert_root_locked ? PORKPRESS_CERT_ROOT : get_site_option( 'porkpress_ssl_cert_root', defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt' );
+$state_root = $state_root_locked ? PORKPRESS_STATE_ROOT : get_site_option( 'porkpress_ssl_state_root', defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl' );
         $auto_reconcile = (bool) get_site_option( 'porkpress_ssl_auto_reconcile', 1 );
         $dry_run        = (bool) get_site_option( 'porkpress_ssl_dry_run', 0 );
 
@@ -653,6 +676,18 @@ echo '</tr>';
 echo '<tr>';
 echo '<th scope="row"><label for="porkpress_api_secret">' . esc_html__( 'Porkbun API Secret', 'porkpress-ssl' ) . '</label></th>';
 echo '<td><input name="porkpress_api_secret" type="text" id="porkpress_api_secret" value="' . esc_attr( $api_secret ) . '" class="regular-text"' . ( $api_secret_locked ? ' readonly' : '' ) . ' /></td>';
+echo '</tr>';
+echo '<tr>';
+echo '<th scope="row"><label for="porkpress_cert_name">' . esc_html__( 'Certificate Name', 'porkpress-ssl' ) . '</label></th>';
+echo '<td><input name="porkpress_cert_name" type="text" id="porkpress_cert_name" value="' . esc_attr( $cert_name ) . '" class="regular-text"' . ( $cert_name_locked ? ' readonly' : '' ) . ' /></td>';
+echo '</tr>';
+echo '<tr>';
+echo '<th scope="row"><label for="porkpress_cert_root">' . esc_html__( 'Certificate Root', 'porkpress-ssl' ) . '</label></th>';
+echo '<td><input name="porkpress_cert_root" type="text" id="porkpress_cert_root" value="' . esc_attr( $cert_root ) . '" class="regular-text"' . ( $cert_root_locked ? ' readonly' : '' ) . ' /></td>';
+echo '</tr>';
+echo '<tr>';
+echo '<th scope="row"><label for="porkpress_state_root">' . esc_html__( 'State Root', 'porkpress-ssl' ) . '</label></th>';
+echo '<td><input name="porkpress_state_root" type="text" id="porkpress_state_root" value="' . esc_attr( $state_root ) . '" class="regular-text"' . ( $state_root_locked ? ' readonly' : '' ) . ' /></td>';
 echo '</tr>';
 echo '<tr>';
 echo '<th scope="row">' . esc_html__( 'Use Let\'s Encrypt Staging', 'porkpress-ssl' ) . '</th>';

--- a/includes/class-certbot-helper.php
+++ b/includes/class-certbot-helper.php
@@ -21,8 +21,14 @@ class Certbot_Helper {
      * @return string
      */
     public static function build_command( array $domains, string $cert_name, bool $staging, bool $renewal = false ): string {
-        $cert_root  = defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt';
-        $state_root = defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl';
+        $cert_root  = function_exists( '\\get_site_option' ) ? \get_site_option(
+                'porkpress_ssl_cert_root',
+                defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt'
+        ) : ( defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt' );
+        $state_root = function_exists( '\\get_site_option' ) ? \get_site_option(
+                'porkpress_ssl_state_root',
+                defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl'
+        ) : ( defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl' );
         $hook = dirname( __DIR__ ) . '/bin/porkbun-hook.php';
         $cmd  = 'certbot certonly --manual --non-interactive --agree-tos --manual-public-ip-logging-ok --preferred-challenges dns';
         $cmd .= ' --manual-auth-hook ' . escapeshellarg( $hook . ' add' );

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -43,7 +43,10 @@ class CLI extends WP_CLI_Command {
                         WP_CLI::error( '--domains is required.' );
                 }
                 $domains   = array_filter( array_map( 'trim', explode( ',', $assoc_args['domains'] ) ) );
-                $cert_name = $assoc_args['cert-name'] ?? 'porkpress-network';
+                $cert_name = $assoc_args['cert-name'] ?? get_site_option(
+                        'porkpress_ssl_cert_name',
+                        defined( 'PORKPRESS_CERT_NAME' ) ? PORKPRESS_CERT_NAME : 'porkpress-network'
+                );
                 $staging   = isset( $assoc_args['staging'] );
                 $this->run_certbot( $domains, $cert_name, $staging, false );
         }
@@ -69,7 +72,10 @@ class CLI extends WP_CLI_Command {
          * @param array $assoc_args Associative arguments.
          */
         public function renew_all( $args, $assoc_args ) {
-                $state_root    = defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl';
+                $state_root    = get_site_option(
+                        'porkpress_ssl_state_root',
+                        defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl'
+                );
                 $manifest_path = rtrim( $state_root, '/\\' ) . '/manifest.json';
                 if ( ! file_exists( $manifest_path ) ) {
                         WP_CLI::error( 'Manifest not found. Issue a certificate first.' );
@@ -79,7 +85,10 @@ class CLI extends WP_CLI_Command {
                         WP_CLI::error( 'Manifest does not contain domains.' );
                 }
                 $domains   = $manifest['domains'];
-                $cert_name = $assoc_args['cert-name'] ?? ( $manifest['cert_name'] ?? 'porkpress-network' );
+                $cert_name = $assoc_args['cert-name'] ?? ( $manifest['cert_name'] ?? get_site_option(
+                        'porkpress_ssl_cert_name',
+                        defined( 'PORKPRESS_CERT_NAME' ) ? PORKPRESS_CERT_NAME : 'porkpress-network'
+                ) );
                 $staging   = isset( $assoc_args['staging'] );
                 $this->run_certbot( $domains, $cert_name, $staging, true );
         }
@@ -93,8 +102,14 @@ class CLI extends WP_CLI_Command {
          * @param bool   $renewal    Force renewal of existing certificate.
          */
         protected function run_certbot( array $domains, string $cert_name, bool $staging, bool $renewal ) {
-                $cert_root  = defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt';
-                $state_root = defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl';
+                $cert_root  = get_site_option(
+                        'porkpress_ssl_cert_root',
+                        defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt'
+                );
+                $state_root = get_site_option(
+                        'porkpress_ssl_state_root',
+                        defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl'
+                );
 
                 if ( ! is_dir( $state_root ) ) {
                         wp_mkdir_p( $state_root );

--- a/includes/class-ssl-service.php
+++ b/includes/class-ssl-service.php
@@ -116,7 +116,10 @@ class SSL_Service {
                        return;
                }
 
-               $cert_name = 'porkpress-network';
+               $cert_name = \get_site_option(
+                       'porkpress_ssl_cert_name',
+                       defined( 'PORKPRESS_CERT_NAME' ) ? PORKPRESS_CERT_NAME : 'porkpress-network'
+               );
                $staging   = function_exists( '\\get_site_option' ) ? (bool) \get_site_option( 'porkpress_ssl_le_staging', 0 ) : false;
 
                $cmd = Renewal_Service::build_certbot_command( $all_domains, $cert_name, $staging, false );

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -29,6 +29,9 @@ if ( ! defined( 'PORKPRESS_CERT_ROOT' ) ) {
 if ( ! defined( 'PORKPRESS_STATE_ROOT' ) ) {
         define( 'PORKPRESS_STATE_ROOT', '/var/lib/porkpress-ssl' );
 }
+if ( ! defined( 'PORKPRESS_CERT_NAME' ) ) {
+        define( 'PORKPRESS_CERT_NAME', 'porkpress-network' );
+}
 
 require_once __DIR__ . '/includes/class-admin.php';
 require_once __DIR__ . '/includes/class-porkbun-client.php';

--- a/tests/MigrationTest.php
+++ b/tests/MigrationTest.php
@@ -1,0 +1,99 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class MigrationTest extends TestCase {
+    protected function setUp(): void {
+        if ( ! defined( 'ABSPATH' ) ) {
+            define( 'ABSPATH', __DIR__ );
+        }
+        if ( ! function_exists( 'absint' ) ) {
+            function absint( $n ) { return abs( intval( $n ) ); }
+        }
+        if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+            define( 'DAY_IN_SECONDS', 86400 );
+        }
+        $GLOBALS['porkpress_site_options'] = array();
+        $GLOBALS['porkpress_events'] = array();
+        if ( ! function_exists( 'get_site_option' ) ) {
+            function get_site_option( $key, $default = null ) { return $GLOBALS['porkpress_site_options'][ $key ] ?? $default; }
+        }
+        if ( ! function_exists( 'update_site_option' ) ) {
+            function update_site_option( $key, $value ) { $GLOBALS['porkpress_site_options'][ $key ] = $value; }
+        }
+        if ( ! function_exists( 'wp_next_scheduled' ) ) {
+            function wp_next_scheduled( $hook ) { return $GLOBALS['porkpress_events'][ $hook ] ?? false; }
+        }
+        if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+            function wp_schedule_single_event( $timestamp, $hook ) { $GLOBALS['porkpress_events'][ $hook ] = $timestamp; }
+        }
+        if ( ! function_exists( 'wp_unschedule_event' ) ) {
+            function wp_unschedule_event( $timestamp, $hook ) { unset( $GLOBALS['porkpress_events'][ $hook ] ); }
+        }
+        if ( ! function_exists( 'wp_json_encode' ) ) {
+            function wp_json_encode( $d ) { return json_encode( $d ); }
+        }
+        if ( ! function_exists( 'wp_mkdir_p' ) ) {
+            function wp_mkdir_p( $dir ) { if ( ! is_dir( $dir ) ) mkdir( $dir, 0777, true ); }
+        }
+        if ( ! function_exists( 'current_time' ) ) {
+            function current_time( $t ) { return gmdate( 'Y-m-d H:i:s' ); }
+        }
+        if ( ! function_exists( 'get_current_user_id' ) ) {
+            function get_current_user_id() { return 0; }
+        }
+        if ( ! function_exists( 'network_admin_url' ) ) {
+            function network_admin_url( $p = '' ) { return ''; }
+        }
+        if ( ! function_exists( 'esc_url' ) ) {
+            function esc_url( $u ) { return $u; }
+        }
+        if ( ! function_exists( 'esc_html__' ) ) {
+            function esc_html__( $t, $d = null ) { return $t; }
+        }
+        if ( ! function_exists( 'esc_attr' ) ) {
+            function esc_attr( $t ) { return $t; }
+        }
+        if ( ! function_exists( 'wp_kses_post' ) ) {
+            function wp_kses_post( $t ) { return $t; }
+        }
+        if ( ! function_exists( 'add_action' ) ) {
+            function add_action( $h, $c ) {}
+        }
+        if ( ! function_exists( 'current_user_can' ) ) {
+            function current_user_can( $c ) { return true; }
+        }
+        if ( ! function_exists( '__' ) ) {
+            function __( $t, $d = null ) { return $t; }
+        }
+        if ( ! function_exists( 'wp_mail' ) ) {
+            function wp_mail( $to, $sub, $msg ) {}
+        }
+        $GLOBALS['wpdb'] = new class { public $base_prefix = 'wp_'; public function insert($t,$d,$f=null){} };
+        require_once __DIR__ . '/../includes/class-logger.php';
+        require_once __DIR__ . '/../includes/class-notifier.php';
+        require_once __DIR__ . '/../includes/class-certbot-helper.php';
+        require_once __DIR__ . '/../includes/class-renewal-service.php';
+    }
+
+    public function testCreatesManifestFromExistingCertificate() {
+        $cert_root = sys_get_temp_dir() . '/porkpress-migrate-cert';
+        $state_root = sys_get_temp_dir() . '/porkpress-migrate-state';
+        update_site_option( 'porkpress_ssl_cert_root', $cert_root );
+        update_site_option( 'porkpress_ssl_state_root', $state_root );
+        update_site_option( 'porkpress_ssl_cert_name', 'adynton.com' );
+        $live_dir = $cert_root . '/live/adynton.com';
+        if ( ! is_dir( $live_dir ) ) { mkdir( $live_dir, 0777, true ); }
+        $cert_path = $live_dir . '/cert.pem';
+        $key_path  = $live_dir . '/privkey.pem';
+        $cmd = 'openssl req -x509 -nodes -newkey rsa:2048 -keyout ' . escapeshellarg( $key_path ) . ' -out ' . escapeshellarg( $cert_path ) . ' -days 1 -subj "/CN=example.com"';
+        exec( $cmd );
+        copy( $cert_path, $live_dir . '/fullchain.pem' );
+        copy( $cert_path, $live_dir . '/chain.pem' );
+        if ( file_exists( $state_root . '/manifest.json' ) ) { unlink( $state_root . '/manifest.json' ); }
+        \PorkPress\SSL\Renewal_Service::maybe_schedule();
+        $this->assertFileExists( $state_root . '/manifest.json' );
+        $manifest = json_decode( file_get_contents( $state_root . '/manifest.json' ), true );
+        $this->assertEquals( 'adynton.com', $manifest['cert_name'] );
+        $this->assertContains( 'example.com', $manifest['domains'] );
+    }
+}


### PR DESCRIPTION
## Summary
- Allow configuring certificate name via network option with constant fallback
- Add network settings for certificate name and storage paths
- Migrate existing certificates into manifest when missing

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689970dbc9bc83338570df718296a4a7