### PR TITLE
Add DNS record management for domain aliases

### DIFF
--- a/includes/class-porkbun-client.php
+++ b/includes/class-porkbun-client.php
@@ -118,17 +118,17 @@ class Porkbun_Client {
 		return $this->deleteRecord( $domain, $record_id );
 	}
 
-	/**
-	 * Create an A record.
-	 */
-	public function createARecord( string $domain, string $name, string $content, int $ttl = 300 ) {
-		return $this->request( "dns/create/{$domain}", [
-			'type'	  => 'A',
-			'name'	  => $name,
-			'content' => $content,
-			'ttl'	  => $ttl,
-		] );
-	}
+        /**
+         * Create an A or AAAA record.
+         */
+        public function createARecord( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
+                return $this->request( "dns/create/{$domain}", [
+                        'type'    => $type,
+                        'name'    => $name,
+                        'content' => $content,
+                        'ttl'     => $ttl,
+                ] );
+        }
 
 	/**
 	 * Delete a record by ID.

--- a/tests/NetworkEventsTest.php
+++ b/tests/NetworkEventsTest.php
@@ -55,6 +55,8 @@ class NetworkEventsTest extends TestCase {
         $wpdb = new MockWpdb();
         $this->service = new class extends \PorkPress\SSL\Domain_Service {
             public function __construct() {}
+            protected function create_a_record( string $domain, int $site_id, int $ttl ) { return true; }
+            protected function delete_a_record( string $domain, int $site_id ) { return true; }
         };
     }
 

--- a/tests/ReconcilerTest.php
+++ b/tests/ReconcilerTest.php
@@ -64,6 +64,8 @@ class ReconcilerTest extends TestCase {
                 $this->client = $client;
                 $this->missing_credentials = false;
             }
+            protected function create_a_record( string $domain, int $site_id, int $ttl ) { return true; }
+            protected function delete_a_record( string $domain, int $site_id ) { return true; }
         };
 
         // Add aliases to the mock table.
@@ -115,6 +117,8 @@ class ReconcilerTest extends TestCase {
                 $this->client              = $client;
                 $this->missing_credentials = false;
             }
+            protected function create_a_record( string $domain, int $site_id, int $ttl ) { return true; }
+            protected function delete_a_record( string $domain, int $site_id ) { return true; }
         };
 
         $service->add_alias( 1, 'existing.com', true );
@@ -169,6 +173,8 @@ class ReconcilerTest extends TestCase {
                 $this->client              = $client;
                 $this->missing_credentials = false;
             }
+            protected function create_a_record( string $domain, int $site_id, int $ttl ) { return true; }
+            protected function delete_a_record( string $domain, int $site_id ) { return true; }
         };
 
         $service->add_alias( 1, 'existing.com', true );


### PR DESCRIPTION
## Summary
- create and remove A/AAAA records when managing domain aliases
- detect network IPv6 and surface missing A records in DNS checks
- allow Porkbun client to specify record type

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689973cd6ad48333a27d7c077934d06e