### PR TITLE
Add certificate lineage adoption support

### DIFF
--- a/tests/CertbotHelperTest.php
+++ b/tests/CertbotHelperTest.php
@@ -26,4 +26,17 @@ class CertbotHelperTest extends TestCase {
 
         $this->assertStringContainsString( "-d '*.example.com'", $cmd );
     }
+
+    public function testParseCertificatesOutput() {
+        require_once __DIR__ . '/../includes/class-certbot-helper.php';
+
+        $output = "Found the following certs:\n  Certificate Name: example.com\n    Serial Number: 123\n    Key Type: RSA\n    Domains: example.com www.example.com\n    Expiry Date: 2024-01-01\n  Certificate Name: other.org\n    Serial Number: 456\n    Key Type: RSA\n    Domains: other.org\n    Expiry Date: 2024-01-01\n";
+
+        $parsed = \PorkPress\SSL\Certbot_Helper::parse_certificates_output( $output );
+
+        $this->assertArrayHasKey( 'example.com', $parsed );
+        $this->assertSame( [ 'example.com', 'www.example.com' ], $parsed['example.com']['domains'] );
+        $this->assertArrayHasKey( 'other.org', $parsed );
+        $this->assertSame( [ 'other.org' ], $parsed['other.org']['domains'] );
+    }
 }


### PR DESCRIPTION
## Summary
- enumerate existing certbot lineages and parse SAN domains
- allow admins to adopt existing certificate lineages from settings UI
- add tests for parsing certbot certificates output

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689cbeb0cfc48333be544664f1d27636