### PR TITLE
Ensure certbot uses full SAN list when updating certificates

### DIFF
--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -118,6 +118,15 @@ class CLI extends WP_CLI_Command {
                         wp_mkdir_p( $cert_root );
                 }
 
+                // If a certificate with this lineage already exists, include all
+                // of its current SANs to ensure we modify the existing
+                // certificate rather than inadvertently creating a new
+                // lineage or dropping names.
+                $existing = Certbot_Helper::list_certificates();
+                if ( isset( $existing[ $cert_name ]['domains'] ) ) {
+                        $domains = array_values( array_unique( array_merge( $existing[ $cert_name ]['domains'], $domains ) ) );
+                }
+
                 $cmd = Certbot_Helper::build_command( $domains, $cert_name, $staging, $renewal );
 
                 $result = WP_CLI::launch( $cmd, false, true );

--- a/tests/SSLServiceTest.php
+++ b/tests/SSLServiceTest.php
@@ -116,6 +116,13 @@ class SSLServiceTest extends TestCase {
             public function __construct() {}
             public function get_aliases( ?int $site_id = null, ?string $domain = null ): array {
                 $this->seen[] = $site_id;
+                if ( null === $site_id ) {
+                    return array(
+                        array( 'domain' => 'example.com' ),
+                        array( 'domain' => 'www.example.com' ),
+                        array( 'domain' => 'foo.com' ),
+                    );
+                }
                 if ( 1 === $site_id ) {
                     return array(
                         array( 'domain' => 'example.com' ),
@@ -150,7 +157,7 @@ class SSLServiceTest extends TestCase {
         $notices = get_site_option( \PorkPress\SSL\Notifier::OPTION );
         $this->assertSame( 'success', $notices[0]['type'] );
 
-        $this->assertSame( [ 1, 2 ], $domains->seen );
+        $this->assertSame( [ null, 1, 2 ], $domains->seen );
         $this->assertSame( [], \PorkPress\SSL\SSL_Service::get_queue() );
     }
 }


### PR DESCRIPTION
## Summary
- Always build certbot commands with the complete set of SANs across the network
- Merge existing lineage domains when invoking certbot via CLI
- Adjust tests for new domain aggregation behavior

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689ce955bf688333ae88e43e1b28c580