### PR TITLE
Refine Certbot integration and WordPress hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ wp porkpress ssl:renew-all [--staging] [--cert-name="porkpress-network"]
 ```
 ## Stand‑alone certbot hook
 
-`bin/porkbun-hook.php` can be used as the manual authentication and cleanup
+`bin/porkpress-hook.php` can be used as the manual authentication and cleanup
 hooks for Certbot. The script loads WordPress to obtain Porkbun credentials and
 log activity via the plugin's `Logger`.
 
@@ -29,14 +29,16 @@ Example certbot invocation:
 ```
 certbot certonly \
   --manual --preferred-challenges dns \
-  --manual-auth-hook '/path/to/bin/porkbun-hook.php add' \
-  --manual-cleanup-hook '/path/to/bin/porkbun-hook.php del' \
+  --manual-auth-hook '/path/to/bin/porkpress-hook.php add' \
+  --manual-cleanup-hook '/path/to/bin/porkpress-hook.php del' \
   -d example.com
 ```
 
-Certbot sets `CERTBOT_DOMAIN` and `CERTBOT_VALIDATION` which the hook consumes.
-If WordPress is not located automatically, set the environment variable
-`WP_LOAD_PATH` to the directory containing `wp-load.php`.
+Certbot sets `CERTBOT_DOMAIN`, `CERTBOT_VALIDATION` and `CERTBOT_TOKEN` which
+the hook logs. If WordPress is not located automatically, either pass
+`--wp-root=/path/to/wordpress` or set the environment variable `WP_ROOT` or
+`WP_LOAD_PATH` to the directory containing `wp-load.php`. The hook also reads
+configuration from `/etc/default/porkpress-ssl` when present.
 
 ## Porkbun API credentials
 
@@ -67,13 +69,17 @@ cp /path/to/porkpress-ssl/sunrise.php /path/to/wordpress/wp-content/sunrise.php
 
 ## Certificate and state locations
 
-Certificates are stored under `${PORKPRESS_CERT_ROOT}/live/<cert-name>/` and a
-JSON manifest is written to `${PORKPRESS_STATE_ROOT}/manifest.json` describing
-the active certificate. By default these roots are `/etc/letsencrypt` and
-`/var/lib/porkpress-ssl` respectively. They can be customized in `wp-config.php`:
+Certbot's default directories are used so existing lineages can be discovered.
+If customization is required, `PORKPRESS_CERT_ROOT`, `PORKPRESS_WORK_DIR` and
+`PORKPRESS_LOGS_DIR` constants (or corresponding network options) are respected
+and surfaced in health checks. A JSON manifest describing the active
+certificate is written to `${PORKPRESS_STATE_ROOT}/manifest.json` which defaults
+to `/var/lib/porkpress-ssl` and can also be overridden in `wp-config.php`:
 
 ```
 define('PORKPRESS_CERT_ROOT', '/etc/letsencrypt');
+define('PORKPRESS_WORK_DIR', '/var/lib/letsencrypt');
+define('PORKPRESS_LOGS_DIR', '/var/log/letsencrypt');
 define('PORKPRESS_STATE_ROOT', '/var/lib/porkpress-ssl');
 define('PORKPRESS_CERT_NAME', 'porkpress-network');
 ```

--- a/includes/class-certbot-helper.php
+++ b/includes/class-certbot-helper.php
@@ -21,22 +21,32 @@ class Certbot_Helper {
      * @return string
      */
     public static function build_command( array $domains, string $cert_name, bool $staging, bool $renewal = false ): string {
-        $cert_root  = function_exists( '\\get_site_option' ) ? \get_site_option(
+        $cert_root = function_exists( '\\get_site_option' ) ? \get_site_option(
                 'porkpress_ssl_cert_root',
-                defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt'
-        ) : ( defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt' );
-        $state_root = function_exists( '\\get_site_option' ) ? \get_site_option(
-                'porkpress_ssl_state_root',
-                defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl'
-        ) : ( defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl' );
-        $hook = dirname( __DIR__ ) . '/bin/porkbun-hook.php';
+                defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : ''
+        ) : ( defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '' );
+        $work_dir = function_exists( '\\get_site_option' ) ? \get_site_option(
+                'porkpress_ssl_work_dir',
+                defined( 'PORKPRESS_WORK_DIR' ) ? PORKPRESS_WORK_DIR : ''
+        ) : ( defined( 'PORKPRESS_WORK_DIR' ) ? PORKPRESS_WORK_DIR : '' );
+        $logs_dir = function_exists( '\\get_site_option' ) ? \get_site_option(
+                'porkpress_ssl_logs_dir',
+                defined( 'PORKPRESS_LOGS_DIR' ) ? PORKPRESS_LOGS_DIR : ''
+        ) : ( defined( 'PORKPRESS_LOGS_DIR' ) ? PORKPRESS_LOGS_DIR : '' );
+        $hook = dirname( __DIR__ ) . '/bin/porkpress-hook.php';
         $cmd  = 'certbot certonly --manual --non-interactive --agree-tos --manual-public-ip-logging-ok --preferred-challenges dns';
         $cmd .= ' --manual-auth-hook ' . escapeshellarg( $hook . ' add' );
         $cmd .= ' --manual-cleanup-hook ' . escapeshellarg( $hook . ' del' );
         $cmd .= ' --cert-name ' . escapeshellarg( $cert_name );
-        $cmd .= ' --config-dir ' . escapeshellarg( $cert_root );
-        $cmd .= ' --work-dir ' . escapeshellarg( $state_root );
-        $cmd .= ' --logs-dir ' . escapeshellarg( $state_root );
+        if ( $cert_root ) {
+            $cmd .= ' --config-dir ' . escapeshellarg( $cert_root );
+        }
+        if ( $work_dir ) {
+            $cmd .= ' --work-dir ' . escapeshellarg( $work_dir );
+        }
+        if ( $logs_dir ) {
+            $cmd .= ' --logs-dir ' . escapeshellarg( $logs_dir );
+        }
         if ( $renewal ) {
             $cmd .= ' --force-renewal';
         }


### PR DESCRIPTION
## Summary
- Avoid overriding Certbot work and logs directories and expose optional config/work/log paths in command builder
- Replace porkbun Certbot hook with `porkpress-hook.php` supporting `--wp-root` and `/etc/default/porkpress-ssl`
- Document new hook usage and directory configuration options

## Testing
- `phpunit tests`
- `php -l bin/porkpress-hook.php`
- `php -l includes/class-certbot-helper.php`


------
https://chatgpt.com/codex/tasks/task_e_689cece24b488333907ffe13dd9df752