### PR TITLE
Run deploy after cert issuance and surface manifest errors

### DIFF
--- a/includes/class-certbot-helper.php
+++ b/includes/class-certbot-helper.php
@@ -37,6 +37,7 @@ class Certbot_Helper {
         $cmd  = 'certbot certonly --manual --non-interactive --agree-tos --manual-public-ip-logging-ok --preferred-challenges dns';
         $cmd .= ' --manual-auth-hook ' . escapeshellarg( $hook . ' add' );
         $cmd .= ' --manual-cleanup-hook ' . escapeshellarg( $hook . ' del' );
+        $cmd .= ' --deploy-hook ' . escapeshellarg( $hook . ' deploy' );
         $cmd .= ' --cert-name ' . escapeshellarg( $cert_name );
         if ( $cert_root ) {
             $cmd .= ' --config-dir ' . escapeshellarg( $cert_root );

--- a/includes/class-ssl-service.php
+++ b/includes/class-ssl-service.php
@@ -163,7 +163,20 @@ class SSL_Service {
                        return;
                }
 
-               Renewal_Service::write_manifest( $all_domains, $cert_name );
+               $manifest_ok = Renewal_Service::write_manifest( $all_domains, $cert_name );
+               $deploy_ok   = Renewal_Service::deploy_to_apache( $cert_name );
+               if ( ! $manifest_ok || ! $deploy_ok ) {
+                       Logger::error(
+                               'issue_certificate',
+                               array(
+                                       'site_ids' => $queue,
+                                       'domains'  => $all_domains,
+                               ),
+                               'post-deploy failed'
+                       );
+                       return;
+               }
+
                Logger::info(
                        'issue_certificate',
                        array(

--- a/tests/CertbotHelperTest.php
+++ b/tests/CertbotHelperTest.php
@@ -12,6 +12,7 @@ class CertbotHelperTest extends TestCase {
 
         $this->assertStringContainsString( '--test-cert', $cmd );
         $this->assertStringContainsString( '--force-renewal', $cmd );
+        $this->assertStringContainsString( '--deploy-hook', $cmd );
         $this->assertStringContainsString( "-d 'example.com'", $cmd );
         $this->assertStringContainsString( "-d 'www.example.com'", $cmd );
     }


### PR DESCRIPTION
## Summary
- invoke deploy hook with certbot to immediately push new certs
- fail fast when manifest write or deployment fails, surfacing admin notices
- provide deploy hook script and CLI integration

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689d0cca429c8333b175107d4518e070