### PR TITLE
Align Apache deployment with Debian vhost layout

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -212,7 +212,23 @@ class Admin {
                        }
                        echo '</ul></div>';
                }
-        }
+
+               $remediations = get_site_option( 'porkpress_ssl_apache_snippets', array() );
+               if ( $remediations ) {
+                       echo '<div class="notice notice-warning"><p>' . esc_html__( 'Apache vhosts need manual SSL directive updates:', 'porkpress-ssl' ) . '</p><ul>';
+                       foreach ( $remediations as $file => $info ) {
+                               $reason = $info['reason'] ?? '';
+                               if ( 'disabled' === $reason ) {
+                                       $reason = __( 'disabled', 'porkpress-ssl' );
+                               } elseif ( 'unwritable' === $reason ) {
+                                       $reason = __( 'unwritable', 'porkpress-ssl' );
+                               }
+                               $label = $file . ( $reason ? ' (' . $reason . ')' : '' );
+                               echo '<li><strong>' . esc_html( $label ) . '</strong><pre>' . esc_html( $info['snippet'] ) . '</pre></li>';
+                       }
+                       echo '</ul></div>';
+               }
+       }
 
        /**
         * Render the sites tab for the network admin page.

--- a/tests/ApacheDeployTest.php
+++ b/tests/ApacheDeployTest.php
@@ -5,54 +5,79 @@ use PHPUnit\Framework\TestCase;
  * @runTestsInSeparateProcesses
  */
 class ApacheDeployTest extends TestCase {
-    public function testDeploymentSymlinksAndReloads() {
-        if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', __DIR__ ); }
+    protected function setUp(): void {
+        if ( ! defined( 'ABSPATH' ) ) {
+            define( 'ABSPATH', __DIR__ );
+        }
+        if ( ! function_exists( 'get_site_option' ) ) {
+            $GLOBALS['porkpress_site_options'] = array();
+            function get_site_option( $key, $default = null ) { return $GLOBALS['porkpress_site_options'][ $key ] ?? $default; }
+            function update_site_option( $key, $value ) { $GLOBALS['porkpress_site_options'][ $key ] = $value; }
+        }
         if ( ! function_exists( 'wp_json_encode' ) ) { function wp_json_encode( $d ) { return json_encode( $d ); } }
+        if ( ! class_exists( '\\PorkPress\\SSL\\Notifier' ) ) {
+            eval('namespace PorkPress\\SSL; class Notifier { const OPTION = "porkpress_ssl_notices"; public static function notify(string $t, string $s, string $m): void {} }');
+        }
+        eval('namespace PorkPress\\SSL; function is_writable($p){ if($p==="/etc/apache2/sites-available/ro.conf") return false; return \is_writable($p); }');
+        if ( ! function_exists( 'wp_mail' ) ) { function wp_mail( $to, $sub, $msg ) {} }
+        if ( ! function_exists( 'network_admin_url' ) ) { function network_admin_url( $p = '' ) { return $p; } }
+        if ( ! function_exists( 'esc_url' ) ) { function esc_url( $u ) { return $u; } }
+        if ( ! function_exists( 'esc_html__' ) ) { function esc_html__( $t, $d = null ) { return $t; } }
+        if ( ! function_exists( '__' ) ) { function __( $t, $d = null ) { return $t; } }
+        $GLOBALS['wpdb'] = new class { public $base_prefix = 'wp_'; public function insert( $t, $d, $f = null ) {} };
         if ( ! function_exists( 'current_time' ) ) { function current_time( $t = '' ) { return date( 'Y-m-d H:i:s' ); } }
         if ( ! function_exists( 'get_current_user_id' ) ) { function get_current_user_id() { return 0; } }
-        $GLOBALS['wpdb'] = new class { public $base_prefix = 'wp_'; public function insert( $t, $d, $f = null ) {} };
 
-        eval(<<<'CODE'
-namespace PorkPress\SSL;
-$GLOBALS['porkpress_site_options'] = array();
-function get_site_option( $key, $default = null ) { return $GLOBALS['porkpress_site_options'][ $key ] ?? $default; }
-function update_site_option( $key, $value ) { $GLOBALS['porkpress_site_options'][ $key ] = $value; }
-$GLOBALS['mock_fs'] = array( 'glob'=>array(), 'mkdir'=>array(), 'symlink'=>array(), 'copy'=>array(), 'unlink'=>array(), 'exists'=>array() );
-function glob( $pattern ) { return $GLOBALS['mock_fs']['glob']; }
-function is_dir( $dir ) { return in_array( $dir, $GLOBALS['mock_fs']['mkdir'], true ); }
-function wp_mkdir_p( $dir ) { $GLOBALS['mock_fs']['mkdir'][] = $dir; return true; }
-function file_exists( $path ) { return in_array( $path, $GLOBALS['mock_fs']['exists'], true ); }
-function unlink( $path ) { $GLOBALS['mock_fs']['unlink'][] = $path; return true; }
-function symlink( $src, $dest ) { $GLOBALS['mock_fs']['symlink'][] = array( $src, $dest ); return true; }
-function copy( $src, $dest ) { $GLOBALS['mock_fs']['copy'][] = array( $src, $dest ); return true; }
-function error_get_last() { return array( 'message' => 'mock' ); }
-CODE);
-        require_once __DIR__ . '/../includes/class-logger.php';
-        require_once __DIR__ . '/../includes/class-renewal-service.php';
+        // Prepare Apache directories and vhosts.
+        @mkdir( '/etc/apache2/sites-available', 0777, true );
+        @mkdir( '/etc/apache2/sites-enabled', 0777, true );
+        foreach ( glob( '/etc/apache2/sites-available/*.conf' ) as $f ) { @unlink( $f ); }
+        foreach ( glob( '/etc/apache2/sites-enabled/*.conf' ) as $f ) { @unlink( $f ); }
+
+        file_put_contents( '/etc/apache2/sites-available/site.conf', "SSLCertificateFile /old/fullchain.pem\nSSLCertificateKeyFile /old/privkey.pem\n" );
+        @unlink( '/etc/apache2/sites-enabled/site.conf' );
+        symlink( '/etc/apache2/sites-available/site.conf', '/etc/apache2/sites-enabled/site.conf' );
+
+        file_put_contents( '/etc/apache2/sites-available/ro.conf', "SSLCertificateFile /old/fullchain.pem\nSSLCertificateKeyFile /old/privkey.pem\n" );
+        chmod( '/etc/apache2/sites-available/ro.conf', 0444 );
+        @unlink( '/etc/apache2/sites-enabled/ro.conf' );
+        symlink( '/etc/apache2/sites-available/ro.conf', '/etc/apache2/sites-enabled/ro.conf' );
+
+        file_put_contents( '/etc/apache2/sites-available/disabled.conf', "SSLCertificateFile /old/fullchain.pem\nSSLCertificateKeyFile /old/privkey.pem\n" );
 
         $GLOBALS['porkpress_site_options'] = array(
             'porkpress_ssl_apache_reload' => 1,
             'porkpress_ssl_apache_reload_cmd' => 'reloadcmd',
             'porkpress_ssl_cert_root' => '/certroot',
         );
-        $GLOBALS['mock_fs']['glob'] = array( '/etc/apache2/sites-available/site.conf' );
+    }
+
+    public function testDeploymentUpdatesAndReportsIssues() {
+        require_once __DIR__ . '/../includes/class-logger.php';
+        require_once __DIR__ . '/../includes/class-renewal-service.php';
+
         $executed = array();
         \PorkPress\SSL\Renewal_Service::$runner = function( $cmd ) use ( &$executed ) {
             $executed[] = $cmd;
             return array( 'code' => 0, 'output' => '' );
         };
+
         $ref = new \ReflectionMethod( \PorkPress\SSL\Renewal_Service::class, 'deploy_to_apache' );
         $ref->setAccessible( true );
-        $ref->invoke( null, 'test' );
-        $expectedDir = '/etc/apache2/sites-available/site';
-        $this->assertContains( $expectedDir, $GLOBALS['mock_fs']['mkdir'] );
-        $this->assertEquals(
-            array(
-                array( '/certroot/live/test/fullchain.pem', $expectedDir . '/fullchain.pem' ),
-                array( '/certroot/live/test/privkey.pem', $expectedDir . '/privkey.pem' ),
-            ),
-            $GLOBALS['mock_fs']['symlink']
-        );
+        $result = $ref->invoke( null, 'test' );
+        $this->assertFalse( $result );
+
+        $contents = file_get_contents( '/etc/apache2/sites-available/site.conf' );
+        $this->assertStringContainsString( '/certroot/live/test/fullchain.pem', $contents );
+        $this->assertStringContainsString( '/certroot/live/test/privkey.pem', $contents );
+
+        $ro_contents = file_get_contents( '/etc/apache2/sites-available/ro.conf' );
+        $this->assertStringNotContainsString( '/certroot/live/test/fullchain.pem', $ro_contents );
+
+        $snips = get_site_option( 'porkpress_ssl_apache_snippets' );
+        $this->assertArrayHasKey( '/etc/apache2/sites-available/ro.conf', $snips );
+        $this->assertArrayHasKey( '/etc/apache2/sites-available/disabled.conf', $snips );
+
         $this->assertEquals( array( 'reloadcmd' ), $executed );
     }
 }

--- a/tests/SSLServiceTest.php
+++ b/tests/SSLServiceTest.php
@@ -111,10 +111,11 @@ class SSLServiceTest extends TestCase {
         file_put_contents( PORKPRESS_CERT_ROOT . '/live/porkpress-network/cert.pem', 'cert' );
 
         @mkdir('/etc/apache2/sites-available', 0777, true);
-        @unlink('/etc/apache2/sites-available/porkpress-network/fullchain.pem');
-        @unlink('/etc/apache2/sites-available/porkpress-network/privkey.pem');
-        @rmdir('/etc/apache2/sites-available/porkpress-network');
-        file_put_contents('/etc/apache2/sites-available/porkpress-network.conf', '');
+        @mkdir('/etc/apache2/sites-enabled', 0777, true);
+        foreach ( glob('/etc/apache2/sites-available/*.conf') as $f ) { @unlink( $f ); }
+        foreach ( glob('/etc/apache2/sites-enabled/*.conf') as $f ) { @unlink( $f ); }
+        file_put_contents('/etc/apache2/sites-available/porkpress-network.conf', "SSLCertificateFile /old/fullchain.pem\nSSLCertificateKeyFile /old/privkey.pem\n");
+        symlink('/etc/apache2/sites-available/porkpress-network.conf', '/etc/apache2/sites-enabled/porkpress-network.conf');
     }
 
     public function testQueueAndRun() {


### PR DESCRIPTION
## Summary
- Update Apache deployment to rewrite enabled vhost SSLCertificate directives to Let's Encrypt live paths
- Surface manual remediation snippets for unwritable or disabled vhosts in the admin dashboard
- Add tests for vhost rewrite logic and update existing tests for new deployment behavior

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689d0fcc8cc883338ae6c715e915850e