### PR TITLE
feat: autodetect Apache reload command

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -154,33 +154,36 @@ class Admin {
                         }
                 }
 
-               $mapped       = count( $service->get_aliases() );
+       $mapped       = count( $service->get_aliases() );
 
-               $reconciler   = new Reconciler( $service );
-               $drift        = $reconciler->reconcile_all( false );
-               $drift_count  = count( $drift['missing_aliases'] ) + count( $drift['stray_aliases'] ) + count( $drift['disabled_sites'] );
+       $reconciler   = new Reconciler( $service );
+       $drift        = $reconciler->reconcile_all( false );
+       $drift_count  = count( $drift['missing_aliases'] ) + count( $drift['stray_aliases'] ) + count( $drift['disabled_sites'] );
 
-               global $wpdb;
-               $table         = Logger::get_table_name();
-               $ssl_log       = $wpdb->get_row( $wpdb->prepare( "SELECT time, result FROM {$table} WHERE action = %s ORDER BY time DESC LIMIT 1", 'issue_certificate' ), ARRAY_A );
-               $ssl_status    = $ssl_log ? $ssl_log['time'] . ' (' . $ssl_log['result'] . ')' : __( 'Never', 'porkpress-ssl' );
-               $reconcile_log = $wpdb->get_row( $wpdb->prepare( "SELECT time, result FROM {$table} WHERE action = %s ORDER BY time DESC LIMIT 1", 'reconcile' ), ARRAY_A );
-               $reconcile_stat = $reconcile_log ? $reconcile_log['time'] . ' (' . $reconcile_log['result'] . ')' : __( 'Never', 'porkpress-ssl' );
+       global $wpdb;
+       $table         = Logger::get_table_name();
+       $ssl_log       = $wpdb->get_row( $wpdb->prepare( "SELECT time, result FROM {$table} WHERE action = %s ORDER BY time DESC LIMIT 1", 'issue_certificate' ), ARRAY_A );
+       $ssl_status    = $ssl_log ? $ssl_log['time'] . ' (' . $ssl_log['result'] . ')' : __( 'Never', 'porkpress-ssl' );
+       $reconcile_log = $wpdb->get_row( $wpdb->prepare( "SELECT time, result FROM {$table} WHERE action = %s ORDER BY time DESC LIMIT 1", 'reconcile' ), ARRAY_A );
+       $reconcile_stat = $reconcile_log ? $reconcile_log['time'] . ' (' . $reconcile_log['result'] . ')' : __( 'Never', 'porkpress-ssl' );
 
-               $cred_status = $service->has_credentials()
-                       ? __( 'Configured', 'porkpress-ssl' )
-                       : __( 'Missing', 'porkpress-ssl' );
+       $cred_status = $service->has_credentials()
+               ? __( 'Configured', 'porkpress-ssl' )
+               : __( 'Missing', 'porkpress-ssl' );
 
-               echo '<div style="display:flex; flex-wrap:wrap; gap:1em;">';
-               $cards = array(
-                       __( 'API Credentials', 'porkpress-ssl' )              => $cred_status,
-                       __( 'Total Porkbun Domains', 'porkpress-ssl' )        => number_format_i18n( $total_domains ),
-                       __( 'Mapped Domains', 'porkpress-ssl' )              => number_format_i18n( $mapped ),
-                       __( 'Drift Alerts', 'porkpress-ssl' )               => number_format_i18n( $drift_count ),
-                       __( 'Upcoming Expiries (≤30 days)', 'porkpress-ssl' ) => number_format_i18n( $upcoming_expiry ),
-                       __( 'Last SSL Run Status', 'porkpress-ssl' )        => $ssl_status,
-                       __( 'Last Reconcile', 'porkpress-ssl' )            => $reconcile_stat,
-               );
+       $apache_cmd = Renewal_Service::get_apache_reload_cmd();
+
+       echo '<div style="display:flex; flex-wrap:wrap; gap:1em;">';
+       $cards = array(
+               __( 'API Credentials', 'porkpress-ssl' )              => $cred_status,
+               __( 'Total Porkbun Domains', 'porkpress-ssl' )        => number_format_i18n( $total_domains ),
+               __( 'Mapped Domains', 'porkpress-ssl' )              => number_format_i18n( $mapped ),
+               __( 'Drift Alerts', 'porkpress-ssl' )               => number_format_i18n( $drift_count ),
+               __( 'Upcoming Expiries (≤30 days)', 'porkpress-ssl' ) => number_format_i18n( $upcoming_expiry ),
+               __( 'Last SSL Run Status', 'porkpress-ssl' )        => $ssl_status,
+               __( 'Last Reconcile', 'porkpress-ssl' )            => $reconcile_stat,
+               __( 'Apache Reload Command', 'porkpress-ssl' )      => $apache_cmd ? $apache_cmd : __( 'Not found', 'porkpress-ssl' ),
+       );
                 foreach ( $cards as $label => $value ) {
                         echo '<div class="card" style="flex:1 1 200px;"><h2>' . esc_html( $label ) . '</h2><p>' . esc_html( $value ) . '</p></div>';
                 }
@@ -783,7 +786,7 @@ $network_wildcard = (bool) get_site_option( 'porkpress_ssl_network_wildcard', 0 
         $auto_reconcile = (bool) get_site_option( 'porkpress_ssl_auto_reconcile', 1 );
         $dry_run        = (bool) get_site_option( 'porkpress_ssl_dry_run', 0 );
         $apache_reload  = (bool) get_site_option( 'porkpress_ssl_apache_reload', 1 );
-        $apache_cmd     = get_site_option( 'porkpress_ssl_apache_reload_cmd', 'apachectl -k reload' );
+        $apache_cmd     = Renewal_Service::get_apache_reload_cmd();
         $certbot_certs = Certbot_Helper::list_certificates();
         if ( ! empty( $certbot_certs ) && ! $cert_name_locked ) {
                 $network_hosts = array();

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -139,7 +139,8 @@ class CLI extends WP_CLI_Command {
                 }
 
                 if ( ! Renewal_Service::deploy_to_apache( $cert_name ) ) {
-                        WP_CLI::error( 'Deployment failed.' );
+                        $err = Renewal_Service::$last_reload['output'] ?? '';
+                        WP_CLI::error( 'Deployment failed: ' . $err );
                 }
 
                 WP_CLI::success( 'Certificate stored.' );

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -85,11 +85,11 @@ function porkpress_ssl_activate() {
                 }
         }
 
-        // Optionally check for apache2ctl.
-        $apache = trim( shell_exec( 'command -v apache2ctl 2>/dev/null' ) );
-        if ( '' === $apache ) {
-                $warnings[] = __( 'apache2ctl not found; automatic Apache reloads may fail.', 'porkpress-ssl' );
-                \PorkPress\SSL\Logger::warn( 'activation_check', array( 'check' => 'apache2ctl' ), 'missing' );
+        // Detect Apache reload command.
+        $apache_cmd = \PorkPress\SSL\Renewal_Service::get_apache_reload_cmd();
+        if ( '' === $apache_cmd ) {
+                $warnings[] = __( 'No Apache reload command detected; automatic Apache reloads may fail.', 'porkpress-ssl' );
+                \PorkPress\SSL\Logger::warn( 'activation_check', array( 'check' => 'apache_reload_cmd' ), 'missing' );
         }
 
         if ( $errors ) {

--- a/tests/ReloadCommandTest.php
+++ b/tests/ReloadCommandTest.php
@@ -1,0 +1,32 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class ReloadCommandTest extends TestCase {
+    protected function setUp(): void {
+        if ( ! defined( 'ABSPATH' ) ) {
+            define( 'ABSPATH', __DIR__ );
+        }
+        $GLOBALS['porkpress_site_options'] = array();
+        if ( ! function_exists( 'get_site_option' ) ) {
+            function get_site_option( $k, $d = null ) { return $GLOBALS['porkpress_site_options'][ $k ] ?? $d; }
+            function update_site_option( $k, $v ) { $GLOBALS['porkpress_site_options'][ $k ] = $v; }
+        }
+        require_once __DIR__ . '/../includes/class-renewal-service.php';
+    }
+
+    public function testDetectsFallbackApachectl() {
+        $bin = sys_get_temp_dir() . '/pp-bin';
+        @mkdir( $bin, 0777, true );
+        foreach ( array( 'systemctl', 'apache2ctl', 'service', 'apachectl' ) as $c ) { @unlink( "$bin/$c" ); }
+        file_put_contents( "$bin/apachectl", "#!/bin/sh\nexit 0;" );
+        chmod( "$bin/apachectl", 0755 );
+        $orig = getenv( 'PATH' );
+        putenv( "PATH=$bin" );
+        $cmd = \PorkPress\SSL\Renewal_Service::get_apache_reload_cmd();
+        $this->assertEquals( 'apachectl -k graceful', $cmd );
+        putenv( "PATH=$orig" );
+    }
+}


### PR DESCRIPTION
## Summary
- detect best Apache reload command at runtime and surface it in health dashboard
- capture and report stderr when reload fails in UI and CLI
- cover reload command detection with unit tests

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689d135cc19c8333b0881006c1afc0d8