### PR TITLE
Add resilient command runner with sudo and WP-CLI fallback

### DIFF
--- a/bin/porkpress-wpcli-wrapper.sh
+++ b/bin/porkpress-wpcli-wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Simple wrapper to trigger PorkPress SSL renewal via WP-CLI.
+# This can be invoked by cron or systemd timers.
+WP=${WP:-wp}
+exec "$WP" porkpress ssl:renew-all "$@"

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -7,6 +7,8 @@
 
 namespace PorkPress\SSL;
 
+require_once __DIR__ . '/class-runner.php';
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -185,6 +187,7 @@ class Admin {
                __( 'Last SSL Run Status', 'porkpress-ssl' )        => $ssl_status,
                __( 'Last Reconcile', 'porkpress-ssl' )            => $reconcile_stat,
                __( 'Apache Reload Command', 'porkpress-ssl' )      => $apache_cmd ? $apache_cmd : __( 'Not found', 'porkpress-ssl' ),
+               __( 'Command Runner', 'porkpress-ssl' )            => Runner::describe(),
        );
                 foreach ( $cards as $label => $value ) {
                         echo '<div class="card" style="flex:1 1 200px;"><h2>' . esc_html( $label ) . '</h2><p>' . esc_html( $value ) . '</p></div>';

--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -7,6 +7,8 @@
 
 namespace PorkPress\SSL;
 
+require_once __DIR__ . '/class-runner.php';
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -243,9 +245,9 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
                        foreach ( $nameservers as $ns ) {
                                $ns_esc = escapeshellarg( $ns );
                                $cmd    = sprintf( 'dig +short %s %s @%s', $d, $type, $ns_esc );
-                               $output = @shell_exec( $cmd );
-                               if ( $output ) {
-                                       $lines = preg_split( '/\s+/', trim( $output ) );
+                               $result = Runner::run( $cmd );
+                               if ( $result['output'] ) {
+                                       $lines = preg_split( '/\s+/', trim( $result['output'] ) );
                                        foreach ( $lines as $line ) {
                                                if ( '' !== $line ) {
                                                        $results[] = rtrim( $line, '.' );

--- a/includes/class-runner.php
+++ b/includes/class-runner.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Command runner abstraction.
+ *
+ * @package PorkPress\SSL
+ */
+
+namespace PorkPress\SSL;
+
+/**
+ * Execute external commands with fallbacks and optional sudo.
+ */
+class Runner {
+    /** Cached detection of available method. */
+    protected static $method = null;
+
+    /** Cached sudo checks. */
+    protected static $sudo_ok = array();
+
+    /**
+     * Determine if a function is available and not disabled.
+     */
+    protected static function function_available( string $func ): bool {
+        if ( ! function_exists( $func ) ) {
+            return false;
+        }
+        $disabled = explode( ',', (string) ini_get( 'disable_functions' ) );
+        $disabled = array_map( 'trim', $disabled );
+        return ! in_array( $func, $disabled, true );
+    }
+
+    /**
+     * Detect execution method.
+     */
+    public static function method(): string {
+        if ( self::$method ) {
+            return self::$method;
+        }
+        if ( self::function_available( 'shell_exec' ) ) {
+            self::$method = 'shell';
+        } elseif ( self::function_available( 'proc_open' ) ) {
+            self::$method = 'proc';
+        } else {
+            self::$method = 'wpcli';
+        }
+        return self::$method;
+    }
+
+    /**
+     * Execute a command without any sudo handling.
+     *
+     * @param string $cmd Command to run.
+     * @return array{code:int,output:string}
+     */
+    protected static function raw_run( string $cmd ): array {
+        $method = self::method();
+        if ( 'shell' === $method ) {
+            $output = shell_exec( $cmd . ' 2>&1; echo "\n$?"' );
+            if ( ! is_string( $output ) ) {
+                return array( 'code' => 1, 'output' => '' );
+            }
+            $lines = preg_split( '/\r?\n/', rtrim( $output ) );
+            $code  = (int) array_pop( $lines );
+            return array(
+                'code'   => $code,
+                'output' => implode( "\n", $lines ),
+            );
+        }
+        if ( 'proc' === $method ) {
+            $desc = array(
+                1 => array( 'pipe', 'w' ),
+                2 => array( 'pipe', 'w' ),
+            );
+            $proc = proc_open( $cmd, $desc, $pipes );
+            if ( ! is_resource( $proc ) ) {
+                return array( 'code' => 1, 'output' => '' );
+            }
+            $output = stream_get_contents( $pipes[1] ) . stream_get_contents( $pipes[2] );
+            foreach ( $pipes as $p ) {
+                fclose( $p );
+            }
+            $code = proc_close( $proc );
+            return array( 'code' => (int) $code, 'output' => $output );
+        }
+        return array( 'code' => 127, 'output' => 'command execution not available' );
+    }
+
+    /**
+     * Check if sudo can run a given binary non-interactively.
+     */
+    protected static function sudo_available( string $bin ): bool {
+        if ( isset( self::$sudo_ok[ $bin ] ) ) {
+            return self::$sudo_ok[ $bin ];
+        }
+        $test   = 'sudo -n ' . escapeshellcmd( $bin ) . ' --version';
+        $result = self::raw_run( $test );
+        self::$sudo_ok[ $bin ] = ( 0 === $result['code'] );
+        return self::$sudo_ok[ $bin ];
+    }
+
+    /**
+     * Maybe prefix a command with sudo depending on context.
+     */
+    protected static function maybe_sudo( string $cmd, string $context ): string {
+        $use = false;
+        if ( 'certbot' === $context ) {
+            $use = function_exists( '\\get_site_option' ) ? (bool) \get_site_option( 'porkpress_ssl_sudo_certbot', 0 ) : false;
+        } elseif ( 'apache' === $context ) {
+            $use = function_exists( '\\get_site_option' ) ? (bool) \get_site_option( 'porkpress_ssl_sudo_apache', 0 ) : false;
+        }
+        if ( ! $use ) {
+            return $cmd;
+        }
+        $bin = strtok( $cmd, ' ' );
+        if ( ! self::sudo_available( $bin ) ) {
+            return $cmd;
+        }
+        return 'sudo ' . $cmd;
+    }
+
+    /**
+     * Run a command.
+     *
+     * @param string $cmd     Command to execute.
+     * @param string $context Command context for sudo allow-list.
+     * @return array{code:int,output:string}
+     */
+    public static function run( string $cmd, string $context = '' ): array {
+        $cmd = self::maybe_sudo( $cmd, $context );
+        return self::raw_run( $cmd );
+    }
+
+    /**
+     * Check whether a command exists in PATH or at a given path.
+     */
+    public static function command_exists( string $cmd ): bool {
+        if ( '' === $cmd ) {
+            return false;
+        }
+        if ( '/' === $cmd[0] ) {
+            return is_executable( $cmd );
+        }
+        $result = self::raw_run( 'command -v ' . escapeshellarg( $cmd ) . ' 2>/dev/null' );
+        return '' !== trim( $result['output'] );
+    }
+
+    /**
+     * Describe current runner mode for health output.
+     */
+    public static function describe(): string {
+        $mode = self::method();
+        switch ( $mode ) {
+            case 'shell':
+                $mode = 'shell_exec';
+                break;
+            case 'proc':
+                $mode = 'proc_open';
+                break;
+            default:
+                $mode = 'wp-cli wrapper required';
+        }
+        $sudo = array();
+        if ( function_exists( '\\get_site_option' ) ) {
+            if ( \get_site_option( 'porkpress_ssl_sudo_certbot', 0 ) ) {
+                $sudo[] = 'certbot';
+            }
+            if ( \get_site_option( 'porkpress_ssl_sudo_apache', 0 ) ) {
+                $sudo[] = 'apache';
+            }
+        }
+        if ( $sudo ) {
+            $mode .= ' (sudo: ' . implode( ',', $sudo ) . ')';
+        }
+        return $mode;
+    }
+}

--- a/includes/class-ssl-service.php
+++ b/includes/class-ssl-service.php
@@ -7,6 +7,8 @@
 
 namespace PorkPress\SSL;
 
+require_once __DIR__ . '/class-runner.php';
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -137,15 +139,9 @@ class SSL_Service {
 
                        $result = null;
                        if ( is_callable( Renewal_Service::$runner ) ) {
-                               $result = call_user_func( Renewal_Service::$runner, $cmd );
+                               $result = call_user_func( Renewal_Service::$runner, $cmd, 'certbot' );
                        } else {
-                               $output = array();
-                               $code   = 0;
-                               exec( $cmd . ' 2>&1', $output, $code );
-                               $result = array(
-                                       'code'   => $code,
-                                       'output' => implode( "\n", $output ),
-                               );
+                               $result = Runner::run( $cmd, 'certbot' );
                        }
 
                        if ( 0 !== $result['code'] ) {

--- a/includes/class-txt-propagation-waiter.php
+++ b/includes/class-txt-propagation-waiter.php
@@ -9,6 +9,8 @@
 
 namespace PorkPress\SSL;
 
+require_once __DIR__ . '/class-runner.php';
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -87,17 +89,15 @@ class TXT_Propagation_Waiter {
          * @return array<int, string> List of TXT records.
          */
         protected function query_txt( string $name, string $resolver ): array {
-                $cmd = sprintf( 'dig +short @%s TXT %s', escapeshellarg( $resolver ), escapeshellarg( $name ) );
-                $output = array();
-                $status = 1;
-                exec( $cmd, $output, $status );
-                if ( 0 !== $status ) {
-                        $message = sprintf( 'dig command failed for resolver %s (exit code %d)', $resolver, $status );
+                $cmd    = sprintf( 'dig +short @%s TXT %s', escapeshellarg( $resolver ), escapeshellarg( $name ) );
+                $result = Runner::run( $cmd );
+                if ( 0 !== $result['code'] ) {
+                        $message = sprintf( 'dig command failed for resolver %s (exit code %d)', $resolver, $result['code'] );
                         trigger_error( $message, E_USER_WARNING );
                         return array();
                 }
                 $records = array();
-                foreach ( $output as $line ) {
+                foreach ( preg_split( '/\r?\n/', trim( $result['output'] ) ) as $line ) {
                         $line = trim( $line );
                         if ( '' === $line ) {
                                 continue;

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -44,6 +44,9 @@ require_once __DIR__ . '/includes/class-txt-propagation-waiter.php';
 require_once __DIR__ . '/includes/class-certbot-helper.php';
 require_once __DIR__ . '/includes/class-renewal-service.php';
 require_once __DIR__ . '/includes/class-notifier.php';
+require_once __DIR__ . '/includes/class-runner.php';
+
+\PorkPress\SSL\Renewal_Service::$runner = array( \PorkPress\SSL\Runner::class, 'run' );
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
         require_once __DIR__ . '/includes/class-cli.php';
@@ -64,15 +67,14 @@ function porkpress_ssl_activate() {
         $warnings = array();
 
        // Verify certbot command.
-       $certbot = trim( shell_exec( 'command -v certbot 2>/dev/null' ) );
-       if ( '' === $certbot ) {
+       $certbot_cmd = get_site_option( 'porkpress_ssl_certbot_cmd', 'certbot' );
+       if ( ! \PorkPress\SSL\Runner::command_exists( $certbot_cmd ) ) {
                $errors[] = __( 'Certbot is required but could not be found.', 'porkpress-ssl' );
                \PorkPress\SSL\Logger::error( 'activation_check', array( 'check' => 'certbot' ), 'missing' );
        }
 
        // Verify dig command.
-       $dig = trim( shell_exec( 'command -v dig 2>/dev/null' ) );
-       if ( '' === $dig ) {
+       if ( ! \PorkPress\SSL\Runner::command_exists( 'dig' ) ) {
                $errors[] = __( 'dig is required but could not be found.', 'porkpress-ssl' );
                \PorkPress\SSL\Logger::error( 'activation_check', array( 'check' => 'dig' ), 'missing' );
        }


### PR DESCRIPTION
## Summary
- add command runner abstraction supporting shell_exec, proc_open, and sudo
- expose runner mode in admin dashboard and enable custom certbot paths
- include WP-CLI cron wrapper for environments without exec access

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689d1a14e8a4833381bdcf26ac0d8d74