### PR TITLE
Add WP-CLI health diagnostics command

### DIFF
--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.2.0
+ * Version:           0.3.0
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.2.0';
+const PORKPRESS_SSL_VERSION = '0.3.0';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 


### PR DESCRIPTION
## Summary
- add `wp porkpress ssl:health` command to verify certbot, directory permissions, lineages, Apache reload command, dig, and DNS functions
- bump plugin version to 0.3.0

## Testing
- `phpunit tests`
- `php -l includes/class-cli.php`
- `php -l porkpress-ssl.php`


------
https://chatgpt.com/codex/tasks/task_e_689d1e314414833380b4221cd63bb99b