### PR TITLE
Replace deprecated certbot test flag with staging flag

### DIFF
--- a/includes/class-certbot-helper.php
+++ b/includes/class-certbot-helper.php
@@ -18,7 +18,9 @@ class Certbot_Helper {
      *
      * @param array  $domains  Domains to include.
      * @param string $cert_name Certificate lineage name.
-     * @param bool   $staging  Whether to use staging.
+     * @param bool   $staging  Whether to use staging. Uses Certbot's `--staging` flag
+     *                        to avoid rate limits during testing. See
+     *                        https://eff-certbot.readthedocs.io/en/stable/using.html#staging
      * @param bool   $renewal  Force renewal.
      * @return string
      */
@@ -55,7 +57,7 @@ class Certbot_Helper {
             $cmd .= ' --force-renewal';
         }
         if ( $staging ) {
-            $cmd .= ' --test-cert';
+            $cmd .= ' --staging';
         }
         foreach ( $domains as $domain ) {
             $domain = strtolower( $domain );

--- a/tests/CertbotHelperTest.php
+++ b/tests/CertbotHelperTest.php
@@ -10,7 +10,7 @@ class CertbotHelperTest extends TestCase {
 
         $cmd = \PorkPress\SSL\Certbot_Helper::build_command( [ 'example.com', 'www.example.com' ], 'test', true, true );
 
-        $this->assertStringContainsString( '--test-cert', $cmd );
+        $this->assertStringContainsString( '--staging', $cmd );
         $this->assertStringContainsString( '--force-renewal', $cmd );
         $this->assertStringContainsString( '--deploy-hook', $cmd );
         $this->assertStringContainsString( "-d 'example.com'", $cmd );

--- a/tests/RenewalServiceTest.php
+++ b/tests/RenewalServiceTest.php
@@ -90,7 +90,7 @@ class RenewalServiceTest extends TestCase {
 
     public function testStagingAddsFlag() {
         $cmd = \PorkPress\SSL\Renewal_Service::build_certbot_command(['example.com'], 'test', true, true);
-        $this->assertStringContainsString('--test-cert', $cmd);
+        $this->assertStringContainsString('--staging', $cmd);
     }
 
     public function testBuildCertbotCommandAddsNetworkWildcard() {


### PR DESCRIPTION
## Summary
- use certbot `--staging` flag instead of deprecated `--test-cert`
- document staging option with link to Certbot docs
- adjust tests for new flag

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689d22d7175883338b971cc464a68ce0