### PR TITLE
Use i18n for progress completion

### DIFF
--- a/assets/domain-bulk.js
+++ b/assets/domain-bulk.js
@@ -17,7 +17,7 @@ jQuery(function($){
         var $progress = $('#porkpress-domain-progress');
         $progress.text('0/'+total);
         function next(){
-            if(!domains.length){$progress.text('Done');return;}
+            if(!domains.length){$progress.text(wp.i18n.__('Done', 'porkpress-ssl'));return;}
             var domain = domains.shift();
             $.post(porkpressBulk.ajaxUrl, {
                 action: 'porkpress_ssl_bulk_action',


### PR DESCRIPTION
## Summary
- replace hardcoded progress completion text with wp.i18n translation using the `porkpress-ssl` domain

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689d256398008333a91b07819ef98330