### PR TITLE
Localize domain bulk action prompts

### DIFF
--- a/assets/domain-bulk.js
+++ b/assets/domain-bulk.js
@@ -1,4 +1,5 @@
 jQuery(function($){
+    const { __, sprintf } = wp.i18n;
     $('#porkpress-domain-actions').on('submit', function(e){
         e.preventDefault();
         var domains = $('input[name="domains[]"]:checked').map(function(){return $(this).val();}).get();
@@ -7,17 +8,17 @@ jQuery(function($){
         if(!domains.length || !action){return;}
         var override = '';
         if(action === 'detach'){
-            override = prompt('Type CONFIRM to detach selected domains');
+            override = prompt(__('Type CONFIRM to detach selected domains', 'porkpress-ssl'));
             if(override !== 'CONFIRM'){return;}
         } else if(action === 'attach'){
-            override = prompt('Type CONFIRM to override DNS check');
+            override = prompt(__('Type CONFIRM to override DNS check', 'porkpress-ssl'));
             if(override === null){return;}
         }
         var total = domains.length, processed = 0;
         var $progress = $('#porkpress-domain-progress');
-        $progress.text('0/'+total);
+        $progress.text(sprintf(__('%1$d/%2$d', 'porkpress-ssl'), 0, total));
         function next(){
-            if(!domains.length){$progress.text('Done');return;}
+            if(!domains.length){$progress.text(__('Done', 'porkpress-ssl'));return;}
             var domain = domains.shift();
             $.post(porkpressBulk.ajaxUrl, {
                 action: 'porkpress_ssl_bulk_action',
@@ -29,10 +30,10 @@ jQuery(function($){
             }, function(resp){
                 processed++;
                 if(!resp.success){
-                    console.error('Action failed', domain, resp.data);
-                    alert('Action failed for ' + domain + ': ' + resp.data);
+                    console.error(__('Action failed', 'porkpress-ssl'), domain, resp.data);
+                    alert(sprintf(__('Action failed for %1$s: %2$s', 'porkpress-ssl'), domain, resp.data));
                 }
-                $progress.text(processed + '/' + total);
+                $progress.text(sprintf(__('%1$d/%2$d', 'porkpress-ssl'), processed, total));
                 next();
             });
         }

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -468,11 +468,12 @@ class Admin {
                echo '<p><a class="button" href="' . esc_url( add_query_arg( array( 'export' => 'mapping-csv' ) ) ) . '">' . esc_html__( 'Export Mapping CSV', 'porkpress-ssl' ) . '</a> ';
                echo '<a class="button" href="' . esc_url( add_query_arg( array( 'export' => 'mapping-json' ) ) ) . '">' . esc_html__( 'Export Mapping JSON', 'porkpress-ssl' ) . '</a></p>';
 
-               wp_enqueue_script( 'porkpress-domain-bulk', plugins_url( '../assets/domain-bulk.js', __FILE__ ), array( 'jquery' ), PORKPRESS_SSL_VERSION, true );
+               wp_enqueue_script( 'porkpress-domain-bulk', plugins_url( '../assets/domain-bulk.js', __FILE__ ), array( 'jquery', 'wp-i18n' ), PORKPRESS_SSL_VERSION, true );
                wp_localize_script( 'porkpress-domain-bulk', 'porkpressBulk', array(
                        'ajaxUrl' => admin_url( 'admin-ajax.php' ),
                        'nonce'   => wp_create_nonce( 'porkpress_ssl_bulk_action' ),
                ) );
+               wp_set_script_translations( 'porkpress-domain-bulk', 'porkpress-ssl' );
 
                echo '<form id="porkpress-domain-actions" method="post">';
                echo '<table class="widefat fixed striped">';


### PR DESCRIPTION
## Summary
- Localize domain bulk action prompts and progress messages with `wp.i18n` helpers
- Load bulk action script with translation support and set up script translations

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689d258648708333a51fdb913f9c5c5b