### PR TITLE
Use prepared statement for logs table check

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -910,7 +910,7 @@ echo '<tr>';
                 global $wpdb;
                 $table_name = $wpdb->prefix . 'porkpress_logs';
 
-                if ( $wpdb->get_var( "SHOW TABLES LIKE '{$table_name}'" ) !== $table_name ) {
+               if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
                         printf( '<div class="error"><p>%s</p></div>', esc_html__( 'Logs table does not exist.', 'porkpress-ssl' ) );
                         return;
                 }


### PR DESCRIPTION
## Summary
- use `$wpdb->prepare` for `SHOW TABLES LIKE` query in Admin logs tab

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689d25bff11083338fd7ee4a2aa5ab09