### PR TITLE
Localize domain bulk prompts for translation

### DIFF
--- a/assets/domain-bulk.js
+++ b/assets/domain-bulk.js
@@ -7,10 +7,10 @@ jQuery(function($){
         if(!domains.length || !action){return;}
         var override = '';
         if(action === 'detach'){
-            override = prompt('Type CONFIRM to detach selected domains');
+            override = prompt(wp.i18n.__('Type CONFIRM to detach selected domains', 'porkpress-ssl'));
             if(override !== 'CONFIRM'){return;}
         } else if(action === 'attach'){
-            override = prompt('Type CONFIRM to override DNS check');
+            override = prompt(wp.i18n.__('Type CONFIRM to override DNS check', 'porkpress-ssl'));
             if(override === null){return;}
         }
         var total = domains.length, processed = 0;
@@ -29,8 +29,8 @@ jQuery(function($){
             }, function(resp){
                 processed++;
                 if(!resp.success){
-                    console.error('Action failed', domain, resp.data);
-                    alert('Action failed for ' + domain + ': ' + resp.data);
+                    console.error(wp.i18n.__('Action failed', 'porkpress-ssl'), domain, resp.data);
+                    alert(wp.i18n.sprintf(wp.i18n.__('Action failed for %1$s: %2$s', 'porkpress-ssl'), domain, resp.data));
                 }
                 $progress.text(processed + '/' + total);
                 next();

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -468,7 +468,8 @@ class Admin {
                echo '<p><a class="button" href="' . esc_url( add_query_arg( array( 'export' => 'mapping-csv' ) ) ) . '">' . esc_html__( 'Export Mapping CSV', 'porkpress-ssl' ) . '</a> ';
                echo '<a class="button" href="' . esc_url( add_query_arg( array( 'export' => 'mapping-json' ) ) ) . '">' . esc_html__( 'Export Mapping JSON', 'porkpress-ssl' ) . '</a></p>';
 
-               wp_enqueue_script( 'porkpress-domain-bulk', plugins_url( '../assets/domain-bulk.js', __FILE__ ), array( 'jquery' ), PORKPRESS_SSL_VERSION, true );
+               wp_enqueue_script( 'porkpress-domain-bulk', plugins_url( '../assets/domain-bulk.js', __FILE__ ), array( 'jquery', 'wp-i18n' ), PORKPRESS_SSL_VERSION, true );
+               wp_set_script_translations( 'porkpress-domain-bulk', 'porkpress-ssl', plugin_dir_path( dirname( __FILE__ ) ) . 'languages' );
                wp_localize_script( 'porkpress-domain-bulk', 'porkpressBulk', array(
                        'ajaxUrl' => admin_url( 'admin-ajax.php' ),
                        'nonce'   => wp_create_nonce( 'porkpress_ssl_bulk_action' ),


### PR DESCRIPTION
## Summary
- wrap domain bulk action prompts and alerts in `wp.i18n` helpers
- load translation functions by adding `wp-i18n` dependency and `wp_set_script_translations`

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689d27e466608333830359ed8e503e2a