### PR TITLE
Use WordPress UUID generator for request IDs

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1239,7 +1239,7 @@ public function render_site_page() {
                 if ( isset( $_POST['porkpress_ssl_confirm'] ) ) {
                         $requests   = get_site_option( self::REQUESTS_OPTION, array() );
                         $requests[] = array(
-                                'id'            => uniqid( '', true ),
+                                'id'            => wp_generate_uuid4(),
                                 'site_id'       => get_current_blog_id(),
                                 'domain'        => $domain,
                                 'justification' => $justification,


### PR DESCRIPTION
## Summary
- Replace `uniqid()` with `wp_generate_uuid4()` for RFC 4122-compliant request IDs

## Testing
- `phpunit --no-progress tests 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689d2ef593dc8333818b4d445e12d0aa