### PR TITLE
Use snake_case and sanitize Porkbun API calls

### DIFF
--- a/bin/porkpress-hook.php
+++ b/bin/porkpress-hook.php
@@ -119,7 +119,7 @@ if ( empty($api_key) || empty($api_secret) ) {
 $client = new Porkbun_Client($api_key, $api_secret);
 
 if ( 'add' === $action || 'auth' === $action ) {
-    $result = $client->createTxtRecord($zone, $record_name, $validation, 600);
+    $result = $client->create_txt_record($zone, $record_name, $validation, 600);
     if ( $result instanceof Porkbun_Client_Error ) {
         Logger::error('certbot_hook', ['action' => 'add', 'domain' => $domain, 'zone' => $zone, 'name' => $record_name, 'token' => $token], $result->message);
         fwrite(STDERR, "{$result->message}\n");
@@ -127,7 +127,7 @@ if ( 'add' === $action || 'auth' === $action ) {
     }
     $timeout   = max( 1, (int) get_site_option( 'porkpress_ssl_txt_timeout', 600 ) );
     $interval  = max( 1, (int) get_site_option( 'porkpress_ssl_txt_interval', 30 ) );
-    $ns_result = $client->getNs( $zone );
+    $ns_result = $client->get_ns( $zone );
     $nameservers = array();
     if ( is_array( $ns_result ) && isset( $ns_result['ns'] ) && is_array( $ns_result['ns'] ) ) {
         $nameservers = $ns_result['ns'];
@@ -170,7 +170,7 @@ if ( 'deploy' === $action || 'renew' === $action ) {
 }
 
 // Deletion path.
-$records = $client->getRecords($zone);
+$records = $client->get_records($zone);
 if ( $records instanceof Porkbun_Client_Error ) {
     Logger::error('certbot_hook', ['action' => 'del', 'domain' => $domain, 'zone' => $zone, 'name' => $record_name, 'token' => $token], $records->message);
     fwrite(STDERR, "{$records->message}\n");
@@ -179,7 +179,7 @@ if ( $records instanceof Porkbun_Client_Error ) {
 $deleted = false;
 foreach ( $records['records'] ?? [] as $rec ) {
     if ( 'TXT' === ($rec['type'] ?? '') && $rec['name'] === $record_name && ($validation ? $rec['content'] === $validation : true) ) {
-        $del = $client->deleteRecord($zone, (int) $rec['id']);
+        $del = $client->delete_record($zone, (int) $rec['id']);
         if ( $del instanceof Porkbun_Client_Error ) {
             Logger::error('certbot_hook', ['action' => 'del', 'domain' => $domain, 'zone' => $zone, 'name' => $record_name, 'id' => $rec['id'], 'token' => $token], $del->message);
             fwrite(STDERR, "{$del->message}\n");

--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -230,7 +230,7 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
        }
 
        protected function dig_dns_records( string $domain ): array {
-               $ns_result = $this->client->getNs( $domain );
+               $ns_result = $this->client->get_ns( $domain );
                $nameservers = array();
                if ( is_array( $ns_result ) && isset( $ns_result['ns'] ) && is_array( $ns_result['ns'] ) ) {
                        $nameservers = $ns_result['ns'];
@@ -442,7 +442,7 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
                 );
             }
 
-            $result = $this->client->listDomains( $current_page, $per_page );
+            $result = $this->client->list_domains( $current_page, $per_page );
 
             if ( $result instanceof Porkbun_Client_Error ) {
                 Notifier::notify( 'error', __( 'Porkbun API error', 'porkpress-ssl' ), $result->message );
@@ -502,7 +502,7 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
      * @return array|Porkbun_Client_Error
      */
     public function check_domain( string $domain ) {
-        $result = $this->client->checkDomain( $domain );
+        $result = $this->client->check_domain( $domain );
         if ( $result instanceof Porkbun_Client_Error ) {
             Notifier::notify( 'error', __( 'Porkbun API error', 'porkpress-ssl' ), $result->message );
         }
@@ -674,21 +674,21 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
         * Ensure a DNS record exists with the desired content.
         */
        protected function ensure_dns_record( string $domain, string $name, string $content, int $ttl, string $type, int $site_id ) {
-               if ( ! isset( $this->client ) || ! method_exists( $this->client, 'retrieveByNameType' ) || ! method_exists( $this->client, 'editByNameType' ) ) {
-                       if ( isset( $this->client ) && method_exists( $this->client, 'createARecord' ) ) {
-                               return $this->client->createARecord( $domain, $name, $content, $ttl, $type );
+               if ( ! isset( $this->client ) || ! method_exists( $this->client, 'retrieve_by_name_type' ) || ! method_exists( $this->client, 'edit_by_name_type' ) ) {
+                       if ( isset( $this->client ) && method_exists( $this->client, 'create_a_record' ) ) {
+                               return $this->client->create_a_record( $domain, $name, $content, $ttl, $type );
                        }
                        return true;
                }
 
                try {
-                       $existing = $this->client->retrieveByNameType( $domain, $name, $type );
+                       $existing = $this->client->retrieve_by_name_type( $domain, $name, $type );
                } catch ( \Throwable $e ) {
                        $existing = new Porkbun_Client_Error( 'client_error', $e->getMessage() );
                }
                if ( $existing instanceof Porkbun_Client_Error ) {
-                       if ( isset( $this->client ) && method_exists( $this->client, 'createARecord' ) ) {
-                               $result = $this->client->createARecord( $domain, $name, $content, $ttl, $type );
+                       if ( isset( $this->client ) && method_exists( $this->client, 'create_a_record' ) ) {
+                               $result = $this->client->create_a_record( $domain, $name, $content, $ttl, $type );
                                if ( $result instanceof Porkbun_Client_Error ) {
                                        \PorkPress\SSL\Logger::error(
                                                'create_a_record',
@@ -719,9 +719,9 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
                }
 
                if ( is_array( $existing ) && ! empty( $existing['records'] ) ) {
-                       $result = $this->client->editByNameType( $domain, $name, $type, $content, $ttl );
+                       $result = $this->client->edit_by_name_type( $domain, $name, $type, $content, $ttl );
                } else {
-                       $result = $this->client->createARecord( $domain, $name, $content, $ttl, $type );
+                       $result = $this->client->create_a_record( $domain, $name, $content, $ttl, $type );
                }
                if ( $result instanceof Porkbun_Client_Error ) {
                        \PorkPress\SSL\Logger::error(
@@ -750,12 +750,12 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
                        return true;
                }
 
-               if ( ! isset( $this->client ) || ! method_exists( $this->client, 'retrieveByNameType' ) || ! method_exists( $this->client, 'editByNameType' ) ) {
+               if ( ! isset( $this->client ) || ! method_exists( $this->client, 'retrieve_by_name_type' ) || ! method_exists( $this->client, 'edit_by_name_type' ) ) {
                        return true;
                }
 
                try {
-                       $this->client->retrieveByNameType( $domain, 'www', 'CNAME' );
+                       $this->client->retrieve_by_name_type( $domain, 'www', 'CNAME' );
                } catch ( \Throwable $e ) {
                        return true;
                }
@@ -775,7 +775,7 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
                $ipv4 = $this->get_network_ip();
                $ipv6 = $this->get_network_ipv6();
 
-               $records = $this->client->getRecords( $domain );
+               $records = $this->client->get_records( $domain );
                if ( $records instanceof Porkbun_Client_Error ) {
                        \PorkPress\SSL\Logger::error( 'delete_a_record', array( 'domain' => $domain, 'site_id' => $site_id ), $records->message );
                        return $records;
@@ -790,7 +790,7 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
                        $content = $rec['content'] ?? '';
 
                        if ( ( 'A' === $type && $ipv4 && $content === $ipv4 ) || ( 'AAAA' === $type && $ipv6 && $content === $ipv6 ) ) {
-                               $del = $this->client->deleteRecord( $domain, (int) $rec['id'] );
+                               $del = $this->client->delete_record( $domain, (int) $rec['id'] );
                                if ( $del instanceof Porkbun_Client_Error ) {
                                        \PorkPress\SSL\Logger::error( 'delete_a_record', array( 'domain' => $domain, 'site_id' => $site_id, 'record_id' => $rec['id'] ), $del->message );
                                        return $del;
@@ -1194,7 +1194,7 @@ UNIQUE KEY domain (domain)
    * @return bool True if the domain exists and is active, false otherwise.
    */
   public function is_domain_active( string $domain ): bool {
-       $result = $this->client->getDomain( $domain );
+       $result = $this->client->get_domain( $domain );
 
        if ( $result instanceof Porkbun_Client_Error ) {
                // If the API fails, assume active to avoid false positives.

--- a/includes/class-porkbun-client.php
+++ b/includes/class-porkbun-client.php
@@ -79,7 +79,7 @@ class Porkbun_Client {
         * "start" offset for paging. The client performs slicing to honour the
         * requested per-page size while only fetching the necessary chunk.
         */
-       public function listDomains( int $page = 1, int $per_page = 100 ) {
+       public function list_domains( int $page = 1, int $per_page = 100 ) {
                $offset      = max( 0, ( $page - 1 ) * $per_page );
                $chunk_start = (int) ( floor( $offset / 1000 ) * 1000 );
 
@@ -101,7 +101,7 @@ class Porkbun_Client {
        /**
         * Retrieve details for a single domain.
         */
-       public function getDomain( string $domain ) {
+       public function get_domain( string $domain ) {
                $domain = strtolower( $domain );
 
                return $this->request( "domain/get/{$domain}", [] );
@@ -110,7 +110,7 @@ class Porkbun_Client {
        /**
         * Check whether a domain is available for registration.
         */
-       public function checkDomain( string $domain ) {
+       public function check_domain( string $domain ) {
                $domain = strtolower( $domain );
 
                return $this->request( "domain/checkDomain/{$domain}", [] );
@@ -119,14 +119,17 @@ class Porkbun_Client {
         /**
          * Retrieve DNS records for a domain.
  */
-        public function getRecords( string $domain ) {
+        public function get_records( string $domain ) {
                 return $this->request( "dns/retrieve/{$domain}", [] );
         }
 
 	/**
 	 * Create a TXT record.
 	 */
-	public function createTxtRecord( string $domain, string $name, string $content, int $ttl = 300 ) {
+	public function create_txt_record( string $domain, string $name, string $content, int $ttl = 300 ) {
+		$name    = sanitize_text_field( $name );
+		$content = sanitize_text_field( $content );
+
 		return $this->request( "dns/create/{$domain}", [
 			'type'	  => 'TXT',
 			'name'	  => $name,
@@ -138,14 +141,17 @@ class Porkbun_Client {
 	/**
 	 * Delete a TXT record by ID.
 	 */
-	public function deleteTxtRecord( string $domain, int $record_id ) {
-		return $this->deleteRecord( $domain, $record_id );
+	public function delete_txt_record( string $domain, int $record_id ) {
+		return $this->delete_record( $domain, $record_id );
 	}
 
         /**
          * Create an A or AAAA record.
          */
-        public function createARecord( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
+        public function create_a_record( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
+		$name    = sanitize_text_field( $name );
+		$content = sanitize_text_field( $content );
+
                 return $this->request( "dns/create/{$domain}", [
                         'type'    => $type,
                         'name'    => $name,
@@ -157,14 +163,17 @@ class Porkbun_Client {
        /**
         * Retrieve a single DNS record by ID.
         */
-       public function getRecord( string $domain, int $record_id ) {
+       public function get_record( string $domain, int $record_id ) {
                return $this->request( "dns/retrieve/{$domain}/{$record_id}", [] );
        }
 
        /**
         * Create a DNS record of any type.
         */
-       public function createRecord( string $domain, string $type, string $name, string $content, int $ttl = 300 ) {
+       public function create_record( string $domain, string $type, string $name, string $content, int $ttl = 300 ) {
+		$name    = sanitize_text_field( $name );
+		$content = sanitize_text_field( $content );
+
                return $this->request( "dns/create/{$domain}", [
                        'type'    => $type,
                        'name'    => $name,
@@ -176,7 +185,10 @@ class Porkbun_Client {
        /**
         * Edit a DNS record by ID.
         */
-       public function editRecord( string $domain, int $record_id, string $type, string $name, string $content, int $ttl = 300 ) {
+       public function edit_record( string $domain, int $record_id, string $type, string $name, string $content, int $ttl = 300 ) {
+		$name    = sanitize_text_field( $name );
+		$content = sanitize_text_field( $content );
+
                return $this->request( "dns/edit/{$domain}/{$record_id}", [
                        'type'    => $type,
                        'name'    => $name,
@@ -188,7 +200,9 @@ class Porkbun_Client {
        /**
         * Retrieve DNS records by name and type.
         */
-       public function retrieveByNameType( string $domain, string $name, string $type ) {
+       public function retrieve_by_name_type( string $domain, string $name, string $type ) {
+		$name = sanitize_text_field( $name );
+
                return $this->request( "dns/retrieveByNameType/{$domain}", [
                        'name' => $name,
                        'type' => $type,
@@ -198,7 +212,10 @@ class Porkbun_Client {
        /**
         * Edit or create a DNS record by name and type.
         */
-       public function editByNameType( string $domain, string $name, string $type, string $content, int $ttl = 300 ) {
+       public function edit_by_name_type( string $domain, string $name, string $type, string $content, int $ttl = 300 ) {
+		$name    = sanitize_text_field( $name );
+		$content = sanitize_text_field( $content );
+
                return $this->request( "dns/editByNameType/{$domain}", [
                        'name'    => $name,
                        'type'    => $type,
@@ -210,7 +227,7 @@ class Porkbun_Client {
        /**
         * Retrieve authoritative nameservers for a domain.
         */
-       public function getNs( string $domain ) {
+       public function get_ns( string $domain ) {
                $domain = strtolower( $domain );
                return $this->request( "domain/getNs/{$domain}", [] );
        }
@@ -218,7 +235,7 @@ class Porkbun_Client {
         /**
          * Delete a record by ID.
          */
-        public function deleteRecord( string $domain, int $record_id ) {
+        public function delete_record( string $domain, int $record_id ) {
                 return $this->request( "dns/delete/{$domain}/{$record_id}", [] );
 	}
 
@@ -233,7 +250,7 @@ class Porkbun_Client {
 
 		while ( true ) {
 			$attempt++;
-			$response = $this->performHttpRequest( $url, $payload, $method );
+			$response = $this->perform_http_request( $url, $payload, $method );
 			$status	  = $response['status'];
 			$body	  = $response['body'];
 
@@ -247,7 +264,7 @@ class Porkbun_Client {
 			}
 
 			if ( ( 429 === $status || ( $status >= 500 && $status < 600 ) ) && $attempt < $this->max_retries ) {
-				$delay = $this->calculateBackoff( $attempt );
+				$delay = $this->calculate_backoff( $attempt );
 				$this->sleep( $delay );
 				continue;
 			}
@@ -266,7 +283,7 @@ class Porkbun_Client {
         /**
          * Low-level HTTP request using WP HTTP API if available, falling back to cURL.
          */
-        protected function performHttpRequest( string $url, array $payload, string $method ): array {
+        protected function perform_http_request( string $url, array $payload, string $method ): array {
                 if ( function_exists( 'wp_remote_request' ) ) {
                         $args = [
                                 'method'  => $method,
@@ -294,7 +311,7 @@ class Porkbun_Client {
                 curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
                 curl_setopt( $ch, CURLOPT_CUSTOMREQUEST, $method );
                 curl_setopt( $ch, CURLOPT_HTTPHEADER, [ 'Content-Type: application/json' ] );
-                curl_setopt( $ch, CURLOPT_POSTFIELDS, json_encode( $payload ) );
+                curl_setopt( $ch, CURLOPT_POSTFIELDS, ( function_exists( 'wp_json_encode' ) ? wp_json_encode( $payload ) : json_encode( $payload ) ) );
                 $body = curl_exec( $ch );
                 if ( false === $body ) {
                         $error = curl_error( $ch );
@@ -309,7 +326,7 @@ class Porkbun_Client {
 	/**
 	 * Calculate exponential backoff with jitter.
 	 */
-	protected function calculateBackoff( int $attempt ): float {
+	protected function calculate_backoff( int $attempt ): float {
 		$base = $this->base_delay * pow( 2, $attempt - 1 );
 		return $base + $this->jitter( $base );
 	}

--- a/tests/BackoffTest.php
+++ b/tests/BackoffTest.php
@@ -7,10 +7,10 @@ require_once __DIR__ . '/../includes/class-porkbun-client.php';
 class BackoffTest extends TestCase {
     public function testExponentialBackoffGrows() {
         $client = new class('key', 'secret') extends \PorkPress\SSL\Porkbun_Client {
-            public function exposeDelay($attempt) { return $this->calculateBackoff($attempt); }
+            public function exposeDelay($attempt) { return $this->calculate_backoff($attempt); }
             protected function jitter(float $base): float { return $base; }
             protected function sleep(float $seconds): void {}
-            protected function performHttpRequest(string $url, array $payload, string $method): array {
+            protected function perform_http_request(string $url, array $payload, string $method): array {
                 return ['status' => 200, 'body' => '{"status":"SUCCESS"}'];
             }
         };
@@ -24,7 +24,7 @@ class BackoffTest extends TestCase {
 
     public function testJitterWithinBounds() {
         $client = new class('key', 'secret') extends \PorkPress\SSL\Porkbun_Client {
-            public function exposeDelay($attempt) { return $this->calculateBackoff($attempt); }
+            public function exposeDelay($attempt) { return $this->calculate_backoff($attempt); }
             protected function jitter(float $base): float { return 0; }
         };
         $d1 = $client->exposeDelay(1);

--- a/tests/DomainServiceTest.php
+++ b/tests/DomainServiceTest.php
@@ -133,7 +133,7 @@ class DomainServiceTest extends TestCase {
         $mock = new class extends \PorkPress\SSL\Porkbun_Client {
             public int $calls = 0;
             public function __construct() {}
-            public function listDomains( int $page = 1, int $per_page = 100 ) {
+            public function list_domains( int $page = 1, int $per_page = 100 ) {
                 $this->calls++;
                 if ( 1 === $this->calls ) {
                     return [
@@ -172,7 +172,7 @@ class DomainServiceTest extends TestCase {
         $mock = new class extends \PorkPress\SSL\Porkbun_Client {
             public int $calls = 0;
             public function __construct() {}
-            public function listDomains( int $page = 1, int $per_page = 100 ) {
+            public function list_domains( int $page = 1, int $per_page = 100 ) {
                 $this->calls++;
                 if ( 1 === $this->calls ) {
                     return [ 'status' => 'SUCCESS', 'domains' => [ [ 'domain' => 'a.com' ] ] ];
@@ -201,7 +201,7 @@ class DomainServiceTest extends TestCase {
         $mock = new class extends \PorkPress\SSL\Porkbun_Client {
             public int $calls = 0;
             public function __construct() {}
-            public function listDomains( int $page = 1, int $per_page = 100 ) {
+            public function list_domains( int $page = 1, int $per_page = 100 ) {
                 $this->calls++;
                 if ( 1 === $this->calls ) {
                     return [ 'status' => 'SUCCESS', 'domains' => [ [ 'domain' => 'one.com' ] ] ];
@@ -228,7 +228,7 @@ class DomainServiceTest extends TestCase {
         $mock = new class extends \PorkPress\SSL\Porkbun_Client {
             public int $calls = 0;
             public function __construct() {}
-            public function listDomains( int $page = 1, int $per_page = 100 ) {
+            public function list_domains( int $page = 1, int $per_page = 100 ) {
                 $this->calls++;
                 return [ 'status' => 'SUCCESS', 'domains' => [ [ 'domain' => 'dup.com' ] ] ];
             }
@@ -248,7 +248,7 @@ class DomainServiceTest extends TestCase {
         $mock = new class extends \PorkPress\SSL\Porkbun_Client {
             public string $last_domain = '';
             public function __construct() {}
-            public function getDomain( string $domain ) {
+            public function get_domain( string $domain ) {
                 $this->last_domain = $domain;
                 return [ 'status' => 'SUCCESS', 'domain' => [ 'status' => 'ACTIVE' ] ];
             }
@@ -397,7 +397,7 @@ class DomainServiceTest extends TestCase {
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public array $args = array();
             public function __construct() {}
-            public function createARecord( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
+            public function create_a_record( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
                 $this->args = func_get_args();
                 return array( 'status' => 'SUCCESS' );
             }
@@ -422,7 +422,7 @@ class DomainServiceTest extends TestCase {
 
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public function __construct() {}
-            public function createARecord( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
+            public function create_a_record( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
                 return new \PorkPress\SSL\Porkbun_Client_Error( 'err', 'fail' );
             }
         };
@@ -453,7 +453,7 @@ class DomainServiceTest extends TestCase {
 
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public function __construct() {}
-            public function createARecord( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) { return array( 'status' => 'SUCCESS' ); }
+            public function create_a_record( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) { return array( 'status' => 'SUCCESS' ); }
         };
 
         $service = new class( $client ) extends \PorkPress\SSL\Domain_Service {
@@ -492,17 +492,17 @@ class DomainServiceTest extends TestCase {
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public array $deleted = array();
             public function __construct() {}
-            public function getRecords( string $domain ) {
+            public function get_records( string $domain ) {
                 return array( 'records' => array(
                     array( 'id' => 1, 'type' => 'A', 'content' => '1.1.1.1', 'name' => '' ),
                     array( 'id' => 2, 'type' => 'AAAA', 'content' => '::1', 'name' => '' ),
                 ) );
             }
-            public function deleteRecord( string $domain, int $record_id ) {
+            public function delete_record( string $domain, int $record_id ) {
                 $this->deleted[] = $record_id;
                 return array( 'status' => 'SUCCESS' );
             }
-            public function createARecord( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
+            public function create_a_record( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
                 return array( 'status' => 'SUCCESS' );
             }
         };
@@ -571,7 +571,7 @@ class DomainServiceTest extends TestCase {
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public array $calls = [];
             public function __construct() {}
-            public function createARecord( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
+            public function create_a_record( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
                 $this->calls[] = [ $domain, $name, $content, $ttl, $type ];
                 return array( 'status' => 'SUCCESS' );
             }
@@ -599,14 +599,14 @@ class DomainServiceTest extends TestCase {
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public array $deleted = [];
             public function __construct() {}
-            public function getRecords( string $domain ) {
+            public function get_records( string $domain ) {
                 return array( 'records' => array(
                     array( 'id' => 1, 'name' => '', 'type' => 'A', 'content' => '1.1.1.1' ),
                     array( 'id' => 2, 'name' => '', 'type' => 'AAAA', 'content' => '::1' ),
                     array( 'id' => 3, 'name' => '', 'type' => 'A', 'content' => '2.2.2.2' ),
                 ) );
             }
-            public function deleteRecord( string $domain, int $record_id ) {
+            public function delete_record( string $domain, int $record_id ) {
                 $this->deleted[] = [ $domain, $record_id ];
                 return array( 'status' => 'SUCCESS' );
             }

--- a/tests/ReconcilerTest.php
+++ b/tests/ReconcilerTest.php
@@ -51,10 +51,10 @@ class ReconcilerTest extends TestCase {
 
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public function __construct() {}
-            public function listDomains( int $page = 1, int $per_page = 100 ) {
+            public function list_domains( int $page = 1, int $per_page = 100 ) {
                 return [ 'status' => 'SUCCESS', 'domains' => [] ];
             }
-            public function getDomain( string $domain ) {
+            public function get_domain( string $domain ) {
                 return [ 'status' => 'SUCCESS', 'domain' => [ 'status' => 'INACTIVE' ] ];
             }
         };
@@ -97,7 +97,7 @@ class ReconcilerTest extends TestCase {
 
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public function __construct() {}
-            public function listDomains( int $page = 1, int $per_page = 100 ) {
+            public function list_domains( int $page = 1, int $per_page = 100 ) {
                 if ( $page > 1 ) {
                     return array( 'status' => 'SUCCESS', 'domains' => array() );
                 }
@@ -153,7 +153,7 @@ class ReconcilerTest extends TestCase {
 
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public function __construct() {}
-            public function listDomains( int $page = 1, int $per_page = 100 ) {
+            public function list_domains( int $page = 1, int $per_page = 100 ) {
                 if ( $page > 1 ) {
                     return array( 'status' => 'SUCCESS', 'domains' => array() );
                 }


### PR DESCRIPTION
## Summary
- Rename `Porkbun_Client` methods to WordPress-style snake_case
- Sanitize DNS record name and content before API requests
- Prefer `wp_json_encode` for cURL payloads when available

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689d2fea7a408333a6662c921daa22f4