### PR TITLE
Use escapeshellarg for sudo availability checks

### DIFF
--- a/includes/class-runner.php
+++ b/includes/class-runner.php
@@ -76,13 +76,14 @@ class Runner {
      * Check if sudo can run a given binary non-interactively.
      */
     protected static function sudo_available( string $bin ): bool {
-        if ( isset( self::$sudo_ok[ $bin ] ) ) {
-            return self::$sudo_ok[ $bin ];
+        $escaped = escapeshellarg( $bin );
+        if ( isset( self::$sudo_ok[ $escaped ] ) ) {
+            return self::$sudo_ok[ $escaped ];
         }
-        $test   = 'sudo -n ' . escapeshellcmd( $bin ) . ' --version';
+        $test   = 'sudo -n ' . $escaped . ' --version';
         $result = self::raw_run( $test );
-        self::$sudo_ok[ $bin ] = ( 0 === $result['code'] );
-        return self::$sudo_ok[ $bin ];
+        self::$sudo_ok[ $escaped ] = ( 0 === $result['code'] );
+        return self::$sudo_ok[ $escaped ];
     }
 
     /**


### PR DESCRIPTION
## Summary
- Use `escapeshellarg` when testing sudo availability to avoid shell injection.
- Align sudo check cache keys with sanitized values.

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689d3aba9ba483339d1cac33cc49b49d