### PR TITLE
Redact email addresses from logs

### DIFF
--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -567,10 +567,10 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
                \PorkPress\SSL\Logger::info(
                        'create_site_start',
                        array(
-                               'domain'      => $domain,
-                               'title'       => $title,
-                               'admin_email' => $admin_email,
-                               'template'    => $template,
+                               'domain'           => $domain,
+                               'title'            => $title,
+                               'admin_email_hash' => hash( 'sha256', strtolower( trim( $admin_email ) ) ),
+                               'template'         => $template,
                        )
                );
 

--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -153,11 +153,32 @@ return $encode ? $context_json : $data;
 }
 
 $secrets = array( 'api_key', 'api_secret', 'key', 'secret', 'password' );
+
+$sanitize = function ( &$arr ) use ( &$sanitize, $secrets ) {
 foreach ( $secrets as $secret ) {
-if ( array_key_exists( $secret, $data ) ) {
-unset( $data[ $secret ] );
+if ( array_key_exists( $secret, $arr ) ) {
+unset( $arr[ $secret ] );
 }
 }
+
+foreach ( $arr as $key => &$value ) {
+if ( is_array( $value ) ) {
+$sanitize( $value );
+} elseif ( is_string( $value ) ) {
+$is_email = false;
+if ( function_exists( 'is_email' ) ) {
+$is_email = (bool) is_email( $value );
+} else {
+$is_email = false !== filter_var( $value, FILTER_VALIDATE_EMAIL );
+}
+if ( $is_email ) {
+unset( $arr[ $key ] );
+}
+}
+}
+};
+
+$sanitize( $data );
 
 if ( ! $encode ) {
 return $data;


### PR DESCRIPTION
## Summary
- Hash admin email before logging site creation
- Strip email addresses from log context
- Cover email redaction in logger tests

## Testing
- `php -l includes/class-domain-service.php`
- `php -l includes/class-logger.php`
- `php -l tests/LoggerTest.php`
- `phpunit tests/LoggerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689d3c08cab483339b8ef2b7e49893f4