### PR TITLE
Include DNS subdomains in domain listings

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -467,7 +467,7 @@ class Admin {
                        $alias_map[ strtolower( $alias['domain'] ) ] = $alias;
                }
 
-               $result = $service->list_domains();
+               $result = $service->list_domains( 1, 100, true );
                 if ( $result instanceof Porkbun_Client_Error ) {
                         $message = $result->message;
                         if ( $result->status ) {

--- a/includes/class-reconciler.php
+++ b/includes/class-reconciler.php
@@ -94,7 +94,7 @@ class Reconciler {
         );
 
         $porkbun = array();
-        $domains = $this->domains->list_domains();
+        $domains = $this->domains->list_domains( 1, 100, true );
         if ( ! ( $domains instanceof Porkbun_Client_Error ) && ! empty( $domains['domains'] ) ) {
             foreach ( $domains['domains'] as $info ) {
                 if ( ! empty( $info['domain'] ) ) {


### PR DESCRIPTION
## Summary
- surface Porkbun DNS records when listing domains so subdomains appear
- show domain-to-site mappings for subdomains in admin UI
- reconcile site aliases against Porkbun domain + DNS list
- cover new subdomain behaviour in tests

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689d4d10b790833390a47988abce5ed9