### PR TITLE
Display DNS records for domains in admin

### DIFF
--- a/assets/domain-dns.js
+++ b/assets/domain-dns.js
@@ -1,0 +1,15 @@
+jQuery(function($){
+    $('#porkpress-domain-actions').on('click', '.porkpress-dns-toggle', function(){
+        var $btn = $(this);
+        var $row = $btn.closest('tr').next('.porkpress-dns-details');
+        $row.stop(true, true).slideToggle(200);
+        $btn.toggleClass('open');
+        var expanded = $btn.hasClass('open');
+        $btn.attr('aria-expanded', expanded);
+        if(expanded){
+            $btn.removeClass('dashicons-arrow-right').addClass('dashicons-arrow-down');
+        }else{
+            $btn.removeClass('dashicons-arrow-down').addClass('dashicons-arrow-right');
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Cache DNS records for each domain during refresh
- Show DNS details with toggling arrow in Domains tab and map domains by DNS targets
- Test domain refresh includes DNS data

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689d5ab6364c8333b31e869ef9d67878