### PR TITLE
Add manual domain refresh caching and dashboard timestamp

### DIFF
--- a/includes/class-porkbun-client.php
+++ b/includes/class-porkbun-client.php
@@ -62,16 +62,23 @@ class Porkbun_Client {
 	private float $base_delay = 1.0;
 
 	/**
+	 * HTTP request timeout in seconds.
+	 */
+	private int $timeout = 20;
+
+	/**
 	 * Constructor.
 	 */
-	public function __construct( string $api_key, string $secret_key, ?string $base_url = null ) {
-		$this->api_key	  = $api_key;
+	public function __construct( string $api_key, string $secret_key, ?string $base_url = null, ?int $timeout = null ) {
+		$this->api_key    = $api_key;
 		$this->secret_key = $secret_key;
 		if ( null !== $base_url ) {
 			$this->base_url = rtrim( $base_url, '/' ) . '/';
 		}
+		if ( null !== $timeout ) {
+			$this->timeout = $timeout;
+		}
 	}
-
        /**
         * List domains with pagination.
         *
@@ -289,6 +296,7 @@ class Porkbun_Client {
                                 'method'  => $method,
                                 'headers' => [ 'Content-Type' => 'application/json' ],
                                 'body'    => wp_json_encode( $payload ),
+			'timeout' => $this->timeout,
                         ];
 
                         if ( 'POST' === strtoupper( $method ) ) {
@@ -311,6 +319,7 @@ class Porkbun_Client {
                 curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
                 curl_setopt( $ch, CURLOPT_CUSTOMREQUEST, $method );
                 curl_setopt( $ch, CURLOPT_HTTPHEADER, [ 'Content-Type: application/json' ] );
+			curl_setopt( $ch, CURLOPT_TIMEOUT, $this->timeout );
                 curl_setopt( $ch, CURLOPT_POSTFIELDS, ( function_exists( 'wp_json_encode' ) ? wp_json_encode( $payload ) : json_encode( $payload ) ) );
                 $body = curl_exec( $ch );
                 if ( false === $body ) {

--- a/includes/class-reconciler.php
+++ b/includes/class-reconciler.php
@@ -94,7 +94,7 @@ class Reconciler {
         );
 
         $porkbun = array();
-        $domains = $this->domains->list_domains( 1, 100, true );
+        $domains = $this->domains->list_domains();
         if ( ! ( $domains instanceof Porkbun_Client_Error ) && ! empty( $domains['domains'] ) ) {
             foreach ( $domains['domains'] as $info ) {
                 if ( ! empty( $info['domain'] ) ) {

--- a/tests/DomainServiceTest.php
+++ b/tests/DomainServiceTest.php
@@ -150,6 +150,7 @@ class DomainServiceTest extends TestCase {
                 }
                 return [ 'status' => 'SUCCESS', 'domains' => [] ];
             }
+            public function get_records( string $domain ) { return [ 'records' => [] ]; }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
@@ -159,8 +160,9 @@ class DomainServiceTest extends TestCase {
             }
         };
 
+        $service->refresh_domains();
         $result = $service->list_domains();
-        $domain = $result['domains'][0];
+        $domain = $result['root_domains'][0];
 
         $this->assertArrayHasKey( 'type', $domain );
         $this->assertArrayHasKey( 'expiry', $domain );
@@ -182,6 +184,7 @@ class DomainServiceTest extends TestCase {
                 }
                 return [ 'status' => 'SUCCESS', 'domains' => [] ];
             }
+            public function get_records( string $domain ) { return [ 'records' => [] ]; }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
@@ -191,6 +194,7 @@ class DomainServiceTest extends TestCase {
             }
         };
 
+        $service->refresh_domains();
         $service->list_domains();
         $service->list_domains();
 
@@ -211,13 +215,15 @@ class DomainServiceTest extends TestCase {
                 }
                 return [ 'status' => 'SUCCESS', 'domains' => [] ];
             }
+            public function get_records( string $domain ) { return [ 'records' => [] ]; }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
             public function __construct( $client ) { $this->client = $client; $this->missing_credentials = false; }
         };
 
-        $result  = $service->list_domains( 1, 1 );
+        $service->refresh_domains( 1, 1 );
+        $result  = $service->list_domains();
         $domains = array_column( $result['domains'], 'domain' );
 
         $this->assertSame( [ 'one.com', 'two.com' ], $domains );
@@ -232,13 +238,14 @@ class DomainServiceTest extends TestCase {
                 $this->calls++;
                 return [ 'status' => 'SUCCESS', 'domains' => [ [ 'domain' => 'dup.com' ] ] ];
             }
+            public function get_records( string $domain ) { return [ 'records' => [] ]; }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
             public function __construct( $client ) { $this->client = $client; $this->missing_credentials = false; }
         };
 
-        $result = $service->list_domains();
+        $result = $service->refresh_domains();
         $this->assertInstanceOf( \PorkPress\SSL\Porkbun_Client_Error::class, $result );
         $this->assertSame( 'duplicate_page', $result->code );
         $this->assertSame( 2, $mock->calls );
@@ -678,7 +685,8 @@ class DomainServiceTest extends TestCase {
             public function __construct( $client ) { $this->client = $client; $this->missing_credentials = false; }
         };
 
-        $result  = $service->list_domains( 1, 100, true );
+        $service->refresh_domains();
+        $result  = $service->list_domains();
         $domains = array_column( $result['domains'], 'domain' );
 
         $this->assertContains( 'adynton.net', $domains );

--- a/tests/DryRunTest.php
+++ b/tests/DryRunTest.php
@@ -14,6 +14,9 @@ if ( ! function_exists( 'get_site_option' ) ) {
         return $default;
     }
 }
+if ( ! function_exists( 'update_site_option' ) ) {
+    function update_site_option( $key, $value ) {}
+}
 if ( ! defined( 'ARRAY_A' ) ) {
     define( 'ARRAY_A', 'ARRAY_A' );
 }
@@ -29,7 +32,7 @@ class DryRunTest extends TestCase {
         $wpdb = new MockWpdb();
 
         $service = new \PorkPress\SSL\Domain_Service( null, true );
-        $result  = $service->list_domains();
+        $result  = $service->refresh_domains();
         $plan    = $service->get_plan();
 
         $this->assertSame( 'SUCCESS', $result['status'] );

--- a/tests/ReconcilerTest.php
+++ b/tests/ReconcilerTest.php
@@ -130,6 +130,7 @@ class ReconcilerTest extends TestCase {
         $service->add_alias( 1, 'existing.com', true );
         $service->add_alias( 3, 'stray.com', true );
 
+        $service->refresh_domains();
         $reconciler = new \PorkPress\SSL\Reconciler( $service );
         $result     = $reconciler->reconcile_all();
 
@@ -189,6 +190,7 @@ class ReconcilerTest extends TestCase {
         $service->add_alias( 1, 'existing.com', true );
         $service->add_alias( 3, 'stray.com', true );
 
+        $service->refresh_domains();
         $reconciler = new \PorkPress\SSL\Reconciler( $service );
         $result     = $reconciler->reconcile_all( false );
 
@@ -235,6 +237,7 @@ class ReconcilerTest extends TestCase {
 
         $service->add_alias( 1, 'dev.adynton.net', true );
 
+        $service->refresh_domains();
         $reconciler = new \PorkPress\SSL\Reconciler( $service );
         $result     = $reconciler->reconcile_all();
 


### PR DESCRIPTION
## Summary
- add stored domain cache with manual refresh and last-refresh API
- show last refresh date on dashboard
- add refresh button in Domains tab and ensure API queries run only on manual refresh
- increase Porkbun API request timeout to prevent cURL 28 errors

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689d540fbc4483338790a1e4cc79dcb7