### PR TITLE
Add configurable timeout for Porkbun client requests

### DIFF
--- a/bin/porkpress-hook.php
+++ b/bin/porkpress-hook.php
@@ -123,13 +123,14 @@ if ( ! $api_key || ! $api_secret ) {
 }
 $api_key    = sanitize_text_field( $api_key );
 $api_secret = sanitize_text_field( $api_secret );
+$timeout   = max( 1, (int) get_site_option( 'porkpress_ssl_api_timeout', 20 ) );
 if ( empty($api_key) || empty($api_secret) ) {
     Logger::error('certbot_hook', ['action' => $action, 'domain' => $domain], 'missing_api_credentials');
     fwrite(STDERR, "Missing API credentials.\n");
     exit(1);
 }
 
-$client = new Porkbun_Client($api_key, $api_secret);
+$client = new Porkbun_Client($api_key, $api_secret, null, $timeout);
 
 if ( 'add' === $action || 'auth' === $action ) {
     $result = $client->create_txt_record($zone, $record_name, $validation, 600);

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -835,6 +835,9 @@ update_site_option( 'porkpress_ssl_le_staging', $staging );
 
 $renew_window = isset( $_POST['porkpress_renew_window'] ) ? absint( wp_unslash( $_POST['porkpress_renew_window'] ) ) : 0;
 update_site_option( 'porkpress_ssl_renew_window', $renew_window );
+$raw_api_timeout = isset( $_POST['porkpress_api_timeout'] ) ? absint( wp_unslash( $_POST['porkpress_api_timeout'] ) ) : 0;
+$api_timeout     = max( 1, $raw_api_timeout );
+update_site_option( 'porkpress_ssl_api_timeout', $api_timeout );
 
 $raw_txt_timeout = isset( $_POST['porkpress_txt_timeout'] ) ? absint( wp_unslash( $_POST['porkpress_txt_timeout'] ) ) : 0;
 $txt_timeout     = max( 1, $raw_txt_timeout );
@@ -883,6 +886,7 @@ $network_wildcard = (bool) get_site_option( 'porkpress_ssl_network_wildcard', 0 
                     'api_secret_changed' => ! $api_secret_locked && isset( $_POST['porkpress_api_secret'] ),
                     'le_staging'         => (bool) $staging,
                     'renew_window'       => $renew_window,
+                    'api_timeout'        => $api_timeout,
                     'txt_timeout'        => $txt_timeout,
                     'txt_interval'       => $txt_interval,
                     'ipv4_override'      => $ipv4_override,
@@ -911,6 +915,7 @@ $api_key    = $api_key_locked ? PORKPRESS_API_KEY : get_site_option( 'porkpress_
 $api_secret = $api_secret_locked ? PORKPRESS_API_SECRET : get_site_option( 'porkpress_ssl_api_secret', '' );
 $staging    = (bool) get_site_option( 'porkpress_ssl_le_staging', 0 );
 $renew_window = absint( get_site_option( 'porkpress_ssl_renew_window', 30 ) );
+$api_timeout  = max( 1, absint( get_site_option( 'porkpress_ssl_api_timeout', 20 ) ) );
 $txt_timeout  = max( 1, absint( get_site_option( 'porkpress_ssl_txt_timeout', 600 ) ) );
 $txt_interval = max( 1, absint( get_site_option( 'porkpress_ssl_txt_interval', 30 ) ) );
 $ipv4_override = get_site_option( 'porkpress_ssl_ipv4_override', '' );
@@ -967,6 +972,10 @@ echo '</tr>';
 echo '<tr>';
 echo '<th scope="row"><label for="porkpress_api_secret">' . esc_html__( 'Porkbun API Secret', 'porkpress-ssl' ) . '</label></th>';
 echo '<td><input name="porkpress_api_secret" type="text" id="porkpress_api_secret" value="' . esc_attr( $api_secret ) . '" class="regular-text"' . ( $api_secret_locked ? ' readonly' : '' ) . ' /></td>';
+echo '</tr>';
+echo '<tr>';
+echo '<th scope="row"><label for="porkpress_api_timeout">' . esc_html__( 'Porkbun API Timeout (seconds)', 'porkpress-ssl' ) . '</label></th>';
+echo '<td><input name="porkpress_api_timeout" type="number" id="porkpress_api_timeout" value="' . esc_attr( $api_timeout ) . '" class="small-text" /></td>';
 echo '</tr>';
 echo '<tr>';
 echo '<th scope="row"><label for="porkpress_cert_name">' . esc_html__( 'Certificate Name', 'porkpress-ssl' ) . '</label></th>';

--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -55,6 +55,7 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
 
                $api_key    = defined( 'PORKPRESS_API_KEY' ) ? PORKPRESS_API_KEY : get_site_option( 'porkpress_ssl_api_key', '' );
                $api_secret = defined( 'PORKPRESS_API_SECRET' ) ? PORKPRESS_API_SECRET : get_site_option( 'porkpress_ssl_api_secret', '' );
+		$timeout   = max( 1, (int) get_site_option( 'porkpress_ssl_api_timeout', 20 ) );
 
                $this->missing_credentials = empty( $api_key ) || empty( $api_secret );
                if ( $this->dry_run ) {
@@ -71,8 +72,8 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
                        $this->client = $client;
                } else {
                        $this->client = $this->dry_run
-                               ? new Porkbun_Client_DryRun( $api_key, $api_secret )
-                               : new Porkbun_Client( $api_key, $api_secret );
+                               ? new Porkbun_Client_DryRun( $api_key, $api_secret, null, $timeout )
+                               : new Porkbun_Client( $api_key, $api_secret, null, $timeout );
                }
        }
 
@@ -286,7 +287,7 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
 
                $failures = get_site_option( self::DNS_PROPAGATION_OPTION, array() );
                $now      = time();
-               $timeout  = (int) get_site_option( 'porkpress_ssl_dns_timeout', 900 );
+		$timeout  = (int) get_site_option( 'porkpress_ssl_dns_timeout', 900 );
 
                if ( ! isset( $failures[ $domain ] ) ) {
                        $failures[ $domain ] = $now;

--- a/includes/class-porkbun-client.php
+++ b/includes/class-porkbun-client.php
@@ -62,11 +62,17 @@ class Porkbun_Client {
 	private float $base_delay = 1.0;
 
 	/**
+	 * Request timeout in seconds.
+	 */
+	private int $timeout = 20;
+
+	/**
 	 * Constructor.
 	 */
-	public function __construct( string $api_key, string $secret_key, ?string $base_url = null ) {
+	public function __construct( string $api_key, string $secret_key, ?string $base_url = null, int $timeout = 20 ) {
 		$this->api_key	  = $api_key;
 		$this->secret_key = $secret_key;
+		$this->timeout    = $timeout;
 		if ( null !== $base_url ) {
 			$this->base_url = rtrim( $base_url, '/' ) . '/';
 		}
@@ -289,6 +295,7 @@ class Porkbun_Client {
                                 'method'  => $method,
                                 'headers' => [ 'Content-Type' => 'application/json' ],
                                 'body'    => wp_json_encode( $payload ),
+                                'timeout' => $this->timeout,
                         ];
 
                         if ( 'POST' === strtoupper( $method ) ) {
@@ -311,6 +318,8 @@ class Porkbun_Client {
                 curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
                 curl_setopt( $ch, CURLOPT_CUSTOMREQUEST, $method );
                 curl_setopt( $ch, CURLOPT_HTTPHEADER, [ 'Content-Type: application/json' ] );
+                curl_setopt( $ch, CURLOPT_TIMEOUT, $this->timeout );
+                curl_setopt( $ch, CURLOPT_CONNECTTIMEOUT, $this->timeout );
                 curl_setopt( $ch, CURLOPT_POSTFIELDS, ( function_exists( 'wp_json_encode' ) ? wp_json_encode( $payload ) : json_encode( $payload ) ) );
                 $body = curl_exec( $ch );
                 if ( false === $body ) {


### PR DESCRIPTION
## Summary
- allow Porkbun client to accept configurable timeout and apply to WP HTTP and cURL
- expose "Porkbun API Timeout" setting with 20s default
- pass timeout through domain service and certbot hook

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689d5d51ff208333837f746860e4ae2d