### PR TITLE
Improve Domains tab UI and caching

### DIFF
--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -499,11 +499,23 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
 
             $records = $this->client->get_records( $root );
             if ( $records instanceof Porkbun_Client_Error ) {
-                $domain_info['dns'] = array();
+                $domain_info['dns']         = array();
+                $domain_info['nameservers'] = array();
+                $domain_info['details']     = array();
                 continue;
             }
 
             $domain_info['dns'] = $records['records'] ?? array();
+
+            $detail = $this->client->get_domain( $root );
+            if ( $detail instanceof Porkbun_Client_Error ) {
+                $domain_info['nameservers'] = array();
+                $domain_info['details']     = array();
+            } else {
+                $info                        = $detail['domain'] ?? $detail;
+                $domain_info['details']      = $info;
+                $domain_info['nameservers']  = $info['ns'] ?? array();
+            }
 
             $seen = array();
             foreach ( $domain_info['dns'] as $rec ) {
@@ -518,9 +530,12 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
                 }
                 $seen[ $key ] = true;
                 $extra[]      = array(
-                    'domain' => $fqdn,
-                    'status' => $domain_info['status'] ?? $domain_info['dnsstatus'] ?? '',
-                    'expiry' => $domain_info['expiry'] ?? $domain_info['expiration'] ?? $domain_info['exdate'] ?? '',
+                    'domain'      => $fqdn,
+                    'status'      => $domain_info['status'] ?? $domain_info['dnsstatus'] ?? '',
+                    'expiry'      => $domain_info['expiry'] ?? $domain_info['expiration'] ?? $domain_info['exdate'] ?? '',
+                    'dns'         => array( $rec ),
+                    'nameservers' => $domain_info['nameservers'] ?? array(),
+                    'details'     => $domain_info['details'] ?? array(),
                 );
             }
         }

--- a/tests/DomainServiceTest.php
+++ b/tests/DomainServiceTest.php
@@ -151,6 +151,7 @@ class DomainServiceTest extends TestCase {
                 return [ 'status' => 'SUCCESS', 'domains' => [] ];
             }
             public function get_records( string $domain ) { return [ 'records' => [] ]; }
+            public function get_domain( string $domain ) { return [ 'status' => 'SUCCESS', 'domain' => [] ]; }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
@@ -185,6 +186,7 @@ class DomainServiceTest extends TestCase {
                 return [ 'status' => 'SUCCESS', 'domains' => [] ];
             }
             public function get_records( string $domain ) { return [ 'records' => [] ]; }
+            public function get_domain( string $domain ) { return [ 'status' => 'SUCCESS', 'domain' => [] ]; }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
@@ -216,6 +218,7 @@ class DomainServiceTest extends TestCase {
                 return [ 'status' => 'SUCCESS', 'domains' => [] ];
             }
             public function get_records( string $domain ) { return [ 'records' => [] ]; }
+            public function get_domain( string $domain ) { return [ 'status' => 'SUCCESS', 'domain' => [] ]; }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
@@ -239,6 +242,7 @@ class DomainServiceTest extends TestCase {
                 return [ 'status' => 'SUCCESS', 'domains' => [ [ 'domain' => 'dup.com' ] ] ];
             }
             public function get_records( string $domain ) { return [ 'records' => [] ]; }
+            public function get_domain( string $domain ) { return [ 'status' => 'SUCCESS', 'domain' => [] ]; }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
@@ -679,6 +683,7 @@ class DomainServiceTest extends TestCase {
             public function get_records( string $domain ) {
                 return array( 'records' => array( array( 'type' => 'A', 'name' => 'dev', 'content' => '1.2.3.4' ) ) );
             }
+            public function get_domain( string $domain ) { return array( 'status' => 'SUCCESS', 'domain' => array() ); }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
@@ -709,6 +714,7 @@ class DomainServiceTest extends TestCase {
             public function get_records( string $domain ) {
                 return array( 'records' => array( array( 'type' => 'CNAME', 'name' => '@', 'content' => 'target.test' ) ) );
             }
+            public function get_domain( string $domain ) { return array( 'status' => 'SUCCESS', 'domain' => array() ); }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {

--- a/tests/ReconcilerTest.php
+++ b/tests/ReconcilerTest.php
@@ -116,6 +116,7 @@ class ReconcilerTest extends TestCase {
             public function get_records( string $domain ) {
                 return array( 'records' => array() );
             }
+            public function get_domain( string $domain ) { return array( 'status' => 'SUCCESS', 'domain' => array() ); }
         };
 
         $service = new class( $client ) extends \PorkPress\SSL\Domain_Service {
@@ -176,6 +177,7 @@ class ReconcilerTest extends TestCase {
             public function get_records( string $domain ) {
                 return array( 'records' => array() );
             }
+            public function get_domain( string $domain ) { return array( 'status' => 'SUCCESS', 'domain' => array() ); }
         };
 
         $service = new class( $client ) extends \PorkPress\SSL\Domain_Service {
@@ -227,6 +229,7 @@ class ReconcilerTest extends TestCase {
                 }
                 return array( 'records' => array() );
             }
+            public function get_domain( string $domain ) { return array( 'status' => 'SUCCESS', 'domain' => array() ); }
         };
 
         $service = new class( $client ) extends \PorkPress\SSL\Domain_Service {


### PR DESCRIPTION
## Summary
- arrange Domains tab action buttons horizontally and rename "Run Now"
- cache DNS and nameserver info for subdomains and add domain detail view
- link domain names to detailed page and adapt tests

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689dd5632694833398ddb6166287f3cf