### PR TITLE
Enforce HTTPS for admin script URLs

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -635,13 +635,25 @@ class Admin {
                echo '<p><a class="button" href="' . esc_url( add_query_arg( array( 'export' => 'mapping-csv' ) ) ) . '">' . esc_html__( 'Export Mapping CSV', 'porkpress-ssl' ) . '</a> ';
                echo '<a class="button" href="' . esc_url( add_query_arg( array( 'export' => 'mapping-json' ) ) ) . '">' . esc_html__( 'Export Mapping JSON', 'porkpress-ssl' ) . '</a></p>';
 
-               wp_enqueue_script( 'porkpress-domain-bulk', plugins_url( '../assets/domain-bulk.js', __FILE__ ), array( 'jquery', 'wp-i18n' ), PORKPRESS_SSL_VERSION, true );
+               wp_enqueue_script(
+                       'porkpress-domain-bulk',
+                       set_url_scheme( plugin_dir_url( dirname( __FILE__ ) ) . 'assets/domain-bulk.js', 'https' ),
+                       array( 'jquery', 'wp-i18n' ),
+                       PORKPRESS_SSL_VERSION,
+                       true
+               );
                wp_set_script_translations( 'porkpress-domain-bulk', 'porkpress-ssl', plugin_dir_path( dirname( __FILE__ ) ) . 'languages' );
                wp_localize_script( 'porkpress-domain-bulk', 'porkpressBulk', array(
                        'ajaxUrl' => admin_url( 'admin-ajax.php' ),
                        'nonce'   => wp_create_nonce( 'porkpress_ssl_bulk_action' ),
                ) );
-               wp_enqueue_script( 'porkpress-domain-dns', plugins_url( '../assets/domain-dns.js', __FILE__ ), array( 'jquery' ), PORKPRESS_SSL_VERSION, true );
+               wp_enqueue_script(
+                       'porkpress-domain-dns',
+                       set_url_scheme( plugin_dir_url( dirname( __FILE__ ) ) . 'assets/domain-dns.js', 'https' ),
+                       array( 'jquery' ),
+                       PORKPRESS_SSL_VERSION,
+                       true
+               );
 
                echo '<form id="porkpress-domain-actions" method="post">';
                echo '<table class="widefat fixed striped">';


### PR DESCRIPTION
## Summary
- ensure admin scripts use plugin_dir_url paths instead of plugins_url
- force HTTPS for domain bulk and DNS scripts via set_url_scheme

## Testing
- `php -l includes/class-admin.php`
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689dde70f764833388919129c01c37e9