### PR TITLE
Increase default TTL to 600 seconds

### DIFF
--- a/includes/class-porkbun-client.php
+++ b/includes/class-porkbun-client.php
@@ -129,10 +129,10 @@ class Porkbun_Client {
                 return $this->request( "dns/retrieve/{$domain}", [] );
         }
 
-	/**
-	 * Create a TXT record.
-	 */
-	public function create_txt_record( string $domain, string $name, string $content, int $ttl = 300 ) {
+       /**
+        * Create a TXT record. Default TTL is 600 seconds.
+        */
+       public function create_txt_record( string $domain, string $name, string $content, int $ttl = 600 ) {
 		$name    = sanitize_text_field( $name );
 		$content = sanitize_text_field( $content );
 
@@ -151,10 +151,10 @@ class Porkbun_Client {
 		return $this->delete_record( $domain, $record_id );
 	}
 
-        /**
-         * Create an A or AAAA record.
-         */
-        public function create_a_record( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
+       /**
+        * Create an A or AAAA record. Default TTL is 600 seconds.
+        */
+       public function create_a_record( string $domain, string $name, string $content, int $ttl = 600, string $type = 'A' ) {
 		$name    = sanitize_text_field( $name );
 		$content = sanitize_text_field( $content );
 
@@ -174,9 +174,9 @@ class Porkbun_Client {
        }
 
        /**
-        * Create a DNS record of any type.
+        * Create a DNS record of any type. Default TTL is 600 seconds.
         */
-       public function create_record( string $domain, string $type, string $name, string $content, int $ttl = 300 ) {
+       public function create_record( string $domain, string $type, string $name, string $content, int $ttl = 600 ) {
 		$name    = sanitize_text_field( $name );
 		$content = sanitize_text_field( $content );
 
@@ -189,9 +189,9 @@ class Porkbun_Client {
        }
 
        /**
-        * Edit a DNS record by ID.
+        * Edit a DNS record by ID. Default TTL is 600 seconds.
         */
-       public function edit_record( string $domain, int $record_id, string $type, string $name, string $content, int $ttl = 300 ) {
+       public function edit_record( string $domain, int $record_id, string $type, string $name, string $content, int $ttl = 600 ) {
 		$name    = sanitize_text_field( $name );
 		$content = sanitize_text_field( $content );
 

--- a/tests/DomainServiceTest.php
+++ b/tests/DomainServiceTest.php
@@ -436,7 +436,7 @@ class DomainServiceTest extends TestCase {
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public array $args = array();
             public function __construct() {}
-            public function create_a_record( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
+            public function create_a_record( string $domain, string $name, string $content, int $ttl = 600, string $type = 'A' ) {
                 $this->args = func_get_args();
                 return array( 'status' => 'SUCCESS' );
             }
@@ -461,7 +461,7 @@ class DomainServiceTest extends TestCase {
 
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public function __construct() {}
-            public function create_a_record( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
+            public function create_a_record( string $domain, string $name, string $content, int $ttl = 600, string $type = 'A' ) {
                 return new \PorkPress\SSL\Porkbun_Client_Error( 'err', 'fail' );
             }
         };
@@ -492,7 +492,7 @@ class DomainServiceTest extends TestCase {
 
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public function __construct() {}
-            public function create_a_record( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) { return array( 'status' => 'SUCCESS' ); }
+            public function create_a_record( string $domain, string $name, string $content, int $ttl = 600, string $type = 'A' ) { return array( 'status' => 'SUCCESS' ); }
         };
 
         $service = new class( $client ) extends \PorkPress\SSL\Domain_Service {
@@ -541,7 +541,7 @@ class DomainServiceTest extends TestCase {
                 $this->deleted[] = $record_id;
                 return array( 'status' => 'SUCCESS' );
             }
-            public function create_a_record( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
+            public function create_a_record( string $domain, string $name, string $content, int $ttl = 600, string $type = 'A' ) {
                 return array( 'status' => 'SUCCESS' );
             }
         };
@@ -610,7 +610,7 @@ class DomainServiceTest extends TestCase {
         $client = new class extends \PorkPress\SSL\Porkbun_Client {
             public array $calls = [];
             public function __construct() {}
-            public function create_a_record( string $domain, string $name, string $content, int $ttl = 300, string $type = 'A' ) {
+            public function create_a_record( string $domain, string $name, string $content, int $ttl = 600, string $type = 'A' ) {
                 $this->calls[] = [ $domain, $name, $content, $ttl, $type ];
                 return array( 'status' => 'SUCCESS' );
             }


### PR DESCRIPTION
## Summary
- raise default DNS TTL from 300 to 600 in Porkbun client
- update client docblocks to note new TTL
- adjust DomainService tests for the new TTL default

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689de74383948333b9cbdd3ff3a11c44