### PR TITLE
Replace deprecated Porkbun domain endpoint

### DIFF
--- a/includes/class-porkbun-client-dryrun.php
+++ b/includes/class-porkbun-client-dryrun.php
@@ -36,8 +36,8 @@ class Porkbun_Client_DryRun extends Porkbun_Client {
             return array( 'status' => 'SUCCESS', 'domains' => array() );
         }
 
-        if ( 0 === strpos( $endpoint, 'domain/get/' ) ) {
-            return array( 'status' => 'SUCCESS', 'domain' => array( 'status' => 'ACTIVE' ) );
+        if ( 0 === strpos( $endpoint, 'domain/getNs/' ) ) {
+            return array( 'status' => 'SUCCESS', 'ns' => array() );
         }
 
         return array( 'status' => 'SUCCESS' );

--- a/includes/class-porkbun-client.php
+++ b/includes/class-porkbun-client.php
@@ -105,12 +105,38 @@ class Porkbun_Client {
        }
 
        /**
-        * Retrieve details for a single domain.
+        * Retrieve nameservers for a domain.
         */
-       public function get_domain( string $domain ) {
+       public function get_nameservers( string $domain ) {
                $domain = strtolower( $domain );
 
-               return $this->request( "domain/get/{$domain}", [] );
+               return $this->request( "domain/getNs/{$domain}", [] );
+       }
+
+       /**
+        * Retrieve details for a single domain via listAll.
+        *
+        * Porkbun's API does not expose a dedicated endpoint for domain
+        * details, so we fetch the full list and filter by domain name.
+        *
+        * @return array|Porkbun_Client_Error Domain info on success, error on failure.
+        */
+       public function get_domain_details( string $domain ) {
+               $domain = strtolower( $domain );
+
+               $result = $this->request( 'domain/listAll', [ 'start' => '0' ] );
+
+               if ( $result instanceof Porkbun_Client_Error ) {
+                       return $result;
+               }
+
+               foreach ( $result['domains'] ?? array() as $info ) {
+                       if ( isset( $info['domain'] ) && strtolower( $info['domain'] ) === $domain ) {
+                               return $info;
+                       }
+               }
+
+               return array();
        }
 
        /**

--- a/tests/DomainServiceTest.php
+++ b/tests/DomainServiceTest.php
@@ -151,7 +151,7 @@ class DomainServiceTest extends TestCase {
                 return [ 'status' => 'SUCCESS', 'domains' => [] ];
             }
             public function get_records( string $domain ) { return [ 'records' => [] ]; }
-            public function get_domain( string $domain ) { return [ 'status' => 'SUCCESS', 'domain' => [] ]; }
+            public function get_nameservers( string $domain ) { return array( 'status' => 'SUCCESS', 'ns' => array() ); }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
@@ -186,7 +186,7 @@ class DomainServiceTest extends TestCase {
                 return [ 'status' => 'SUCCESS', 'domains' => [] ];
             }
             public function get_records( string $domain ) { return [ 'records' => [] ]; }
-            public function get_domain( string $domain ) { return [ 'status' => 'SUCCESS', 'domain' => [] ]; }
+            public function get_nameservers( string $domain ) { return array( 'status' => 'SUCCESS', 'ns' => array() ); }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
@@ -218,7 +218,7 @@ class DomainServiceTest extends TestCase {
                 return [ 'status' => 'SUCCESS', 'domains' => [] ];
             }
             public function get_records( string $domain ) { return [ 'records' => [] ]; }
-            public function get_domain( string $domain ) { return [ 'status' => 'SUCCESS', 'domain' => [] ]; }
+            public function get_nameservers( string $domain ) { return array( 'status' => 'SUCCESS', 'ns' => array() ); }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
@@ -242,7 +242,7 @@ class DomainServiceTest extends TestCase {
                 return [ 'status' => 'SUCCESS', 'domains' => [ [ 'domain' => 'dup.com' ] ] ];
             }
             public function get_records( string $domain ) { return [ 'records' => [] ]; }
-            public function get_domain( string $domain ) { return [ 'status' => 'SUCCESS', 'domain' => [] ]; }
+            public function get_nameservers( string $domain ) { return array( 'status' => 'SUCCESS', 'ns' => array() ); }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
@@ -259,9 +259,9 @@ class DomainServiceTest extends TestCase {
         $mock = new class extends \PorkPress\SSL\Porkbun_Client {
             public string $last_domain = '';
             public function __construct() {}
-            public function get_domain( string $domain ) {
+            public function get_domain_details( string $domain ) {
                 $this->last_domain = $domain;
-                return [ 'status' => 'SUCCESS', 'domain' => [ 'status' => 'ACTIVE' ] ];
+                return array( 'domain' => $domain, 'status' => 'ACTIVE' );
             }
         };
 
@@ -282,7 +282,7 @@ class DomainServiceTest extends TestCase {
 
         $mock = new class extends \PorkPress\SSL\Porkbun_Client {
             public function __construct() {}
-            public function get_domain( string $domain ) {
+            public function get_domain_details( string $domain ) {
                 return new \PorkPress\SSL\Porkbun_Client_Error( 'fail', 'error' );
             }
         };
@@ -298,7 +298,7 @@ class DomainServiceTest extends TestCase {
         $table = \PorkPress\SSL\Logger::get_table_name();
         $this->assertNotEmpty( $wpdb->data[ $table ] );
         $log = $wpdb->data[ $table ][0];
-        $this->assertSame( 'get_domain', $log['action'] );
+        $this->assertSame( 'get_domain_details', $log['action'] );
         $this->assertSame( 'error', $log['result'] );
         $ctx = json_decode( $log['context'], true );
         $this->assertSame( 'example.com', $ctx['domain'] );
@@ -683,7 +683,7 @@ class DomainServiceTest extends TestCase {
             public function get_records( string $domain ) {
                 return array( 'records' => array( array( 'type' => 'A', 'name' => 'dev', 'content' => '1.2.3.4' ) ) );
             }
-            public function get_domain( string $domain ) { return array( 'status' => 'SUCCESS', 'domain' => array() ); }
+            public function get_nameservers( string $domain ) { return array( 'status' => 'SUCCESS', 'ns' => array() ); }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {
@@ -714,7 +714,7 @@ class DomainServiceTest extends TestCase {
             public function get_records( string $domain ) {
                 return array( 'records' => array( array( 'type' => 'CNAME', 'name' => '@', 'content' => 'target.test' ) ) );
             }
-            public function get_domain( string $domain ) { return array( 'status' => 'SUCCESS', 'domain' => array() ); }
+            public function get_nameservers( string $domain ) { return array( 'status' => 'SUCCESS', 'ns' => array() ); }
         };
 
         $service = new class( $mock ) extends \PorkPress\SSL\Domain_Service {

--- a/tests/ReconcilerTest.php
+++ b/tests/ReconcilerTest.php
@@ -54,8 +54,8 @@ class ReconcilerTest extends TestCase {
             public function list_domains( int $page = 1, int $per_page = 100 ) {
                 return [ 'status' => 'SUCCESS', 'domains' => [] ];
             }
-            public function get_domain( string $domain ) {
-                return [ 'status' => 'SUCCESS', 'domain' => [ 'status' => 'INACTIVE' ] ];
+            public function get_domain_details( string $domain ) {
+                return array( 'domain' => $domain, 'status' => 'INACTIVE' );
             }
             public function get_records( string $domain ) {
                 return array( 'records' => array() );
@@ -116,7 +116,7 @@ class ReconcilerTest extends TestCase {
             public function get_records( string $domain ) {
                 return array( 'records' => array() );
             }
-            public function get_domain( string $domain ) { return array( 'status' => 'SUCCESS', 'domain' => array() ); }
+            public function get_nameservers( string $domain ) { return array( 'status' => 'SUCCESS', 'ns' => array() ); }
         };
 
         $service = new class( $client ) extends \PorkPress\SSL\Domain_Service {
@@ -177,7 +177,7 @@ class ReconcilerTest extends TestCase {
             public function get_records( string $domain ) {
                 return array( 'records' => array() );
             }
-            public function get_domain( string $domain ) { return array( 'status' => 'SUCCESS', 'domain' => array() ); }
+            public function get_nameservers( string $domain ) { return array( 'status' => 'SUCCESS', 'ns' => array() ); }
         };
 
         $service = new class( $client ) extends \PorkPress\SSL\Domain_Service {
@@ -229,7 +229,7 @@ class ReconcilerTest extends TestCase {
                 }
                 return array( 'records' => array() );
             }
-            public function get_domain( string $domain ) { return array( 'status' => 'SUCCESS', 'domain' => array() ); }
+            public function get_nameservers( string $domain ) { return array( 'status' => 'SUCCESS', 'ns' => array() ); }
         };
 
         $service = new class( $client ) extends \PorkPress\SSL\Domain_Service {


### PR DESCRIPTION
## Summary
- replace deprecated `/domain/get` usage with `get_domain_details` (listAll) and `get_nameservers`
- update domain service and dry-run client to use new endpoints
- adjust tests for new client methods

## Testing
- `phpunit --no-progress tests`

------
https://chatgpt.com/codex/tasks/task_e_689de928afb083338cf609ca2797f5e5