### PR TITLE
Include labels when listing domains

### DIFF
--- a/includes/class-porkbun-client.php
+++ b/includes/class-porkbun-client.php
@@ -90,7 +90,8 @@ class Porkbun_Client {
                $chunk_start = (int) ( floor( $offset / 1000 ) * 1000 );
 
                $result = $this->request( 'domain/listAll', [
-                       'start' => (string) $chunk_start,
+                       'start'         => (string) $chunk_start,
+                       'includeLabels' => 'yes',
                ] );
 
                if ( $result instanceof Porkbun_Client_Error ) {

--- a/tests/DryRunTest.php
+++ b/tests/DryRunTest.php
@@ -38,5 +38,6 @@ class DryRunTest extends TestCase {
         $this->assertSame( 'SUCCESS', $result['status'] );
         $this->assertNotEmpty( $plan );
         $this->assertSame( 'domain/listAll', $plan[0]['endpoint'] );
+        $this->assertSame( 'yes', $plan[0]['payload']['includeLabels'] );
     }
 }


### PR DESCRIPTION
## Summary
- request labels with domain listAll API calls
- assert label inclusion in dry-run plan

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689debc7d27c8333bfd972d5b78a941a