### PR TITLE
Add additional Porkbun API helpers and tests

### DIFF
--- a/includes/class-porkbun-client-dryrun.php
+++ b/includes/class-porkbun-client-dryrun.php
@@ -25,6 +25,111 @@ class Porkbun_Client_DryRun extends Porkbun_Client {
     /**
      * {@inheritDoc}
      */
+    public function ping() {
+        return parent::ping();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get_pricing( string $tld ) {
+        return parent::get_pricing( $tld );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function update_nameservers( string $domain, array $nameservers ) {
+        return parent::update_nameservers( $domain, $nameservers );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function add_url_forward( string $domain, string $subdomain, string $destination, string $type = '302', bool $wildcard = false ) {
+        return parent::add_url_forward( $domain, $subdomain, $destination, $type, $wildcard );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get_url_forwarding( string $domain ) {
+        return parent::get_url_forwarding( $domain );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function delete_url_forward( string $domain, int $id ) {
+        return parent::delete_url_forward( $domain, $id );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function create_glue_record( string $domain, string $hostname, array $ips ) {
+        return parent::create_glue_record( $domain, $hostname, $ips );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function update_glue_record( string $domain, string $hostname, array $ips ) {
+        return parent::update_glue_record( $domain, $hostname, $ips );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function delete_glue_record( string $domain, string $hostname ) {
+        return parent::delete_glue_record( $domain, $hostname );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get_glue_records( string $domain ) {
+        return parent::get_glue_records( $domain );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function delete_by_name_type( string $domain, string $subdomain, string $type ) {
+        return parent::delete_by_name_type( $domain, $subdomain, $type );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function create_dnssec( string $domain, string $key_tag, string $algorithm, string $digest_type, string $digest ) {
+        return parent::create_dnssec( $domain, $key_tag, $algorithm, $digest_type, $digest );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function retrieve_dnssec( string $domain ) {
+        return parent::retrieve_dnssec( $domain );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function delete_dnssec( string $domain ) {
+        return parent::delete_dnssec( $domain );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function retrieve_ssl_bundle( string $domain ) {
+        return parent::retrieve_ssl_bundle( $domain );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     protected function request( string $endpoint, array $payload, string $method = 'POST' ) {
         $this->plan[] = array(
             'endpoint' => $endpoint,

--- a/includes/class-porkbun-client.php
+++ b/includes/class-porkbun-client.php
@@ -380,4 +380,162 @@ class Porkbun_Client {
 	protected function sleep( float $seconds ): void {
 		usleep( (int) ( $seconds * 1000000 ) );
 	}
+       /**
+        * Ping the Porkbun API.
+        */
+       public function ping() {
+               return $this->request( 'ping', array() );
+       }
+
+       /**
+        * Retrieve pricing information for a TLD.
+        */
+       public function get_pricing( string $tld ) {
+               $tld = strtolower( sanitize_text_field( $tld ) );
+
+               return $this->request( "pricing/get/{$tld}", array() );
+       }
+
+       /**
+        * Update nameservers for a domain.
+        */
+       public function update_nameservers( string $domain, array $nameservers ) {
+               $domain  = strtolower( $domain );
+               $payload = array( 'ns' => array_values( array_map( 'sanitize_text_field', $nameservers ) ) );
+
+               return $this->request( "domain/updateNs/{$domain}", $payload );
+       }
+
+       /**
+        * Add a URL forward.
+        */
+       public function add_url_forward( string $domain, string $subdomain, string $destination, string $type = '302', bool $wildcard = false ) {
+               $domain      = strtolower( $domain );
+               $subdomain   = sanitize_text_field( $subdomain );
+               $destination = sanitize_text_field( $destination );
+
+               $payload = array(
+                       'name'        => $subdomain,
+                       'destination' => $destination,
+                       'type'        => $type,
+               );
+
+               if ( $wildcard ) {
+                       $payload['wildcard'] = '1';
+               }
+
+               return $this->request( "domain/addUrlForward/{$domain}", $payload );
+       }
+
+       /**
+        * Retrieve URL forwarding configuration.
+        */
+       public function get_url_forwarding( string $domain ) {
+               $domain = strtolower( $domain );
+
+               return $this->request( "domain/getUrlForwarding/{$domain}", array() );
+       }
+
+       /**
+        * Delete a URL forward by ID.
+        */
+       public function delete_url_forward( string $domain, int $id ) {
+               $domain = strtolower( $domain );
+
+               return $this->request( "domain/deleteUrlForward/{$domain}/{$id}", array() );
+       }
+
+       /**
+        * Create a glue record.
+        */
+       public function create_glue_record( string $domain, string $hostname, array $ips ) {
+               $domain   = strtolower( $domain );
+               $hostname = sanitize_text_field( $hostname );
+               $ips      = array_values( array_map( 'sanitize_text_field', $ips ) );
+
+               return $this->request( "domain/createGlue/{$domain}", array( 'hostname' => $hostname, 'ips' => $ips ) );
+       }
+
+       /**
+        * Update a glue record.
+        */
+       public function update_glue_record( string $domain, string $hostname, array $ips ) {
+               $domain   = strtolower( $domain );
+               $hostname = sanitize_text_field( $hostname );
+               $ips      = array_values( array_map( 'sanitize_text_field', $ips ) );
+
+               return $this->request( "domain/updateGlue/{$domain}/{$hostname}", array( 'ips' => $ips ) );
+       }
+
+       /**
+        * Delete a glue record.
+        */
+       public function delete_glue_record( string $domain, string $hostname ) {
+               $domain   = strtolower( $domain );
+               $hostname = sanitize_text_field( $hostname );
+
+               return $this->request( "domain/deleteGlue/{$domain}/{$hostname}", array() );
+       }
+
+       /**
+        * Retrieve glue records for a domain.
+        */
+       public function get_glue_records( string $domain ) {
+               $domain = strtolower( $domain );
+
+               return $this->request( "domain/getGlue/{$domain}", array() );
+       }
+
+       /**
+        * Delete DNS records by subdomain and type.
+        */
+       public function delete_by_name_type( string $domain, string $subdomain, string $type ) {
+               $subdomain = sanitize_text_field( $subdomain );
+               $type      = sanitize_text_field( $type );
+
+               return $this->request( "dns/deleteByNameType/{$domain}/{$type}/{$subdomain}", array() );
+       }
+
+       /**
+        * Create DNSSEC DS record.
+        */
+       public function create_dnssec( string $domain, string $key_tag, string $algorithm, string $digest_type, string $digest ) {
+               $domain  = strtolower( $domain );
+               $payload = array(
+                       'keyTag'     => sanitize_text_field( $key_tag ),
+                       'algorithm'  => sanitize_text_field( $algorithm ),
+                       'digestType' => sanitize_text_field( $digest_type ),
+                       'digest'     => sanitize_text_field( $digest ),
+               );
+
+               return $this->request( "dnssec/create/{$domain}", $payload );
+       }
+
+       /**
+        * Retrieve DNSSEC DS records.
+        */
+       public function retrieve_dnssec( string $domain ) {
+               $domain = strtolower( $domain );
+
+               return $this->request( "dnssec/retrieve/{$domain}", array() );
+       }
+
+       /**
+        * Delete DNSSEC DS records for a domain.
+        */
+       public function delete_dnssec( string $domain ) {
+               $domain = strtolower( $domain );
+
+               return $this->request( "dnssec/delete/{$domain}", array() );
+       }
+
+       /**
+        * Retrieve SSL bundle for a domain.
+        */
+       public function retrieve_ssl_bundle( string $domain ) {
+               $domain = strtolower( $domain );
+
+               return $this->request( "ssl/retrieve/{$domain}", array() );
+       }
+
 }

--- a/tests/PorkbunClientTest.php
+++ b/tests/PorkbunClientTest.php
@@ -1,0 +1,83 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ );
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+    function sanitize_text_field( $str ) {
+        return $str;
+    }
+}
+
+require_once __DIR__ . '/../includes/class-porkbun-client.php';
+require_once __DIR__ . '/../includes/class-porkbun-client-dryrun.php';
+
+class PorkbunClientTest extends TestCase {
+    public function test_builds_endpoints_and_payloads() {
+        $client = new \PorkPress\SSL\Porkbun_Client_DryRun( 'key', 'secret' );
+
+        $client->ping();
+        $last = end( $client->plan );
+        $this->assertSame( 'ping', $last['endpoint'] );
+
+        $client->get_pricing( 'com' );
+        $last = end( $client->plan );
+        $this->assertSame( 'pricing/get/com', $last['endpoint'] );
+
+        $client->update_nameservers( 'example.com', array( 'ns1.example.com', 'ns2.example.com' ) );
+        $last = end( $client->plan );
+        $this->assertSame( 'domain/updateNs/example.com', $last['endpoint'] );
+        $this->assertSame( array( 'ns1.example.com', 'ns2.example.com' ), $last['payload']['ns'] );
+
+        $client->add_url_forward( 'example.com', 'www', 'https://dest', '301', true );
+        $last = end( $client->plan );
+        $this->assertSame( 'domain/addUrlForward/example.com', $last['endpoint'] );
+        $this->assertSame( 'www', $last['payload']['name'] );
+
+        $client->get_url_forwarding( 'example.com' );
+        $last = end( $client->plan );
+        $this->assertSame( 'domain/getUrlForwarding/example.com', $last['endpoint'] );
+
+        $client->delete_url_forward( 'example.com', 42 );
+        $last = end( $client->plan );
+        $this->assertSame( 'domain/deleteUrlForward/example.com/42', $last['endpoint'] );
+
+        $client->create_glue_record( 'example.com', 'ns1', array( '1.2.3.4' ) );
+        $last = end( $client->plan );
+        $this->assertSame( 'domain/createGlue/example.com', $last['endpoint'] );
+        $this->assertSame( array( 'hostname' => 'ns1', 'ips' => array( '1.2.3.4' ) ), $last['payload'] );
+
+        $client->update_glue_record( 'example.com', 'ns1', array( '1.2.3.5' ) );
+        $last = end( $client->plan );
+        $this->assertSame( 'domain/updateGlue/example.com/ns1', $last['endpoint'] );
+
+        $client->delete_glue_record( 'example.com', 'ns1' );
+        $last = end( $client->plan );
+        $this->assertSame( 'domain/deleteGlue/example.com/ns1', $last['endpoint'] );
+
+        $client->get_glue_records( 'example.com' );
+        $last = end( $client->plan );
+        $this->assertSame( 'domain/getGlue/example.com', $last['endpoint'] );
+
+        $client->delete_by_name_type( 'example.com', 'www', 'A' );
+        $last = end( $client->plan );
+        $this->assertSame( 'dns/deleteByNameType/example.com/A/www', $last['endpoint'] );
+
+        $client->create_dnssec( 'example.com', '1', '2', '3', 'abcd' );
+        $last = end( $client->plan );
+        $this->assertSame( 'dnssec/create/example.com', $last['endpoint'] );
+
+        $client->retrieve_dnssec( 'example.com' );
+        $last = end( $client->plan );
+        $this->assertSame( 'dnssec/retrieve/example.com', $last['endpoint'] );
+
+        $client->delete_dnssec( 'example.com' );
+        $last = end( $client->plan );
+        $this->assertSame( 'dnssec/delete/example.com', $last['endpoint'] );
+
+        $client->retrieve_ssl_bundle( 'example.com' );
+        $last = end( $client->plan );
+        $this->assertSame( 'ssl/retrieve/example.com', $last['endpoint'] );
+    }
+}


### PR DESCRIPTION
## Summary
- expand Porkbun client with ping, pricing lookup, nameserver updates, URL forwarding, glue record management, DNSSEC, DNS bulk deletes and SSL retrieval
- mirror new client helpers in dry-run variant
- test new helpers build expected endpoints and payloads

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689dedd44344833388ff7584a21f5215