### PR TITLE
Validate DNS arguments for Porkbun client

### DIFF
--- a/tests/DomainServiceTest.php
+++ b/tests/DomainServiceTest.php
@@ -910,11 +910,11 @@ class DomainServiceTest extends TestCase {
             public array $edited  = array();
             public array $deleted = array();
             public function __construct() {}
-            public function create_record( string $domain, string $type, string $name, string $content, int $ttl = 600 ) {
+            public function create_record( string $domain, string $type, string $name, string $content, int $ttl = 600, ?int $prio = null ) {
                 $this->created = func_get_args();
                 return array( 'status' => 'SUCCESS' );
             }
-            public function edit_record( string $domain, int $record_id, string $type, string $name, string $content, int $ttl = 600 ) {
+            public function edit_record( string $domain, int $record_id, string $type, string $name, string $content, int $ttl = 600, ?int $prio = null ) {
                 $this->edited = func_get_args();
                 return array( 'status' => 'SUCCESS' );
             }


### PR DESCRIPTION
## Summary
- add `validate_dns_args` helper to check record type, content, ttl and priority
- call validation from `create_record` and `edit_record`
- document supported record types and fields

## Testing
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689e3683bad88333829197c5165fab8a