### PR TITLE
Refresh alias statuses and cache after DNS updates

### DIFF
--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -981,7 +981,7 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
 
                $this->clear_domain_cache();
                $fqdn = $name ? "{$name}.{$domain}" : $domain;
-               $this->touch_aliases_for_domain( $fqdn );
+               $this->touch_aliases_for_domain( $fqdn, 'active' );
                return true;
        }
 
@@ -1041,7 +1041,7 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
 
                $this->clear_domain_cache();
                $fqdn = $name ? "{$name}.{$domain}" : $domain;
-               $this->touch_aliases_for_domain( $fqdn );
+               $this->touch_aliases_for_domain( $fqdn, 'active' );
                return true;
        }
 
@@ -1084,7 +1084,7 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
                }
 
                $this->clear_domain_cache();
-               $this->touch_aliases_for_domain( $domain );
+               $this->touch_aliases_for_domain( $domain, 'inactive' );
                return true;
        }
 
@@ -1093,13 +1093,13 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
         *
         * @param string $domain Domain to match.
         */
-       protected function touch_aliases_for_domain( string $domain ): void {
+       protected function touch_aliases_for_domain( string $domain, string $status = 'active' ): void {
                $aliases = $this->get_aliases();
                $match   = '.' . $domain;
                foreach ( $aliases as $alias ) {
                        $alias_domain = $alias['domain'];
                        if ( $alias_domain === $domain || substr( $alias_domain, -strlen( $match ) ) === $match ) {
-                               $this->update_alias( (int) $alias['site_id'], $alias_domain, array( 'status' => 'active' ) );
+                               $this->update_alias( (int) $alias['site_id'], $alias_domain, array( 'status' => $status ) );
                        }
                }
        }

--- a/tests/DomainServiceTest.php
+++ b/tests/DomainServiceTest.php
@@ -951,7 +951,7 @@ class DomainServiceTest extends TestCase {
         $service->update_alias( 1, 'sub.example.com', array( 'status' => 'inactive' ) );
         $this->assertTrue( $service->delete_dns_record( 'example.com', 5 ) );
         $alias = $service->get_aliases( null, 'sub.example.com' )[0];
-        $this->assertSame( 'active', $alias['status'] );
+        $this->assertSame( 'inactive', $alias['status'] );
         $this->assertSame( array( 'example.com', 5 ), $client->deleted );
         $this->assertSame( 3, $service->cache_clear_count );
 


### PR DESCRIPTION
## Summary
- mark related alias entries active on DNS add/update and inactive on delete
- centralize alias status updates via `touch_aliases_for_domain()` and clear the domain cache
- adjust domain service tests for new inactive status on record removal

## Testing
- `phpunit tests/DomainServiceTest.php`
- `phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_689e3b0e8d508333abca82f386e27c74