### PR TITLE
chore: document v3 DNS API and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ it manages differ for each case:
 * **Subdomain** – `A` and `AAAA` records are created for the subdomain. No
   `www` alias is added by default.
 
+All DNS operations use Porkbun's API v3 endpoints for record
+creation, retrieval, editing and deletion.
+
 ### Optional `www` CNAMEs for subdomains
 
 If a `www` alias should be created for a subdomain such as
@@ -94,6 +97,21 @@ conditional logic:
 add_filter( 'porkpress_ssl_add_www_cname', function( $enabled, $domain ) {
     return $domain === 'shop.example.com';
 }, 10, 2 );
+```
+
+### Editing and deleting records
+
+The bundled Porkbun client provides helpers for modifying or removing
+DNS entries through the v3 API:
+
+```php
+$client = new PorkPress\SSL\Porkbun_Client( 'pk_...', 'sk_...' );
+
+// Update an A record.
+$client->edit_record( 'example.com', 123, 'A', '', '198.51.100.5', 600 );
+
+// Delete the record.
+$client->delete_record( 'example.com', 123 );
 ```
 
 ## Enabling `sunrise.php`

--- a/includes/class-porkbun-client.php
+++ b/includes/class-porkbun-client.php
@@ -149,12 +149,14 @@ class Porkbun_Client {
                return $this->request( "domain/checkDomain/{$domain}", [] );
        }
 
-        /**
-         * Retrieve DNS records for a domain.
- */
-        public function get_records( string $domain ) {
-                return $this->request( "dns/retrieve/{$domain}", [] );
-        }
+       /**
+        * Retrieve DNS records for a domain.
+        *
+        * Uses Porkbun's v3 DNS retrieve endpoint: `/api/json/v3/dns/retrieve/{domain}`.
+        */
+       public function get_records( string $domain ) {
+               return $this->request( "dns/retrieve/{$domain}", [] );
+       }
 
        /**
         * Create a TXT record. Default TTL is 600 seconds.
@@ -171,12 +173,14 @@ class Porkbun_Client {
 		] );
 	}
 
-	/**
-	 * Delete a TXT record by ID.
-	 */
-	public function delete_txt_record( string $domain, int $record_id ) {
-		return $this->delete_record( $domain, $record_id );
-	}
+       /**
+        * Delete a TXT record by ID.
+        *
+        * Uses Porkbun's v3 DNS delete endpoint: `/api/json/v3/dns/delete/{domain}/{id}`.
+        */
+       public function delete_txt_record( string $domain, int $record_id ) {
+               return $this->delete_record( $domain, $record_id );
+       }
 
        /**
         * Create an A or AAAA record. Default TTL is 600 seconds.
@@ -201,6 +205,8 @@ class Porkbun_Client {
 
        /**
         * Retrieve a single DNS record by ID.
+        *
+        * Uses Porkbun's v3 DNS retrieve endpoint: `/api/json/v3/dns/retrieve/{domain}/{id}`.
         */
        public function get_record( string $domain, int $record_id ) {
                return $this->request( "dns/retrieve/{$domain}/{$record_id}", [] );
@@ -251,6 +257,8 @@ class Porkbun_Client {
         * Optional fields:
         * - ttl (int): Time to live in seconds.
         * - prio (int): Priority for MX and SRV records.
+        *
+        * Uses Porkbun's v3 DNS edit endpoint: `/api/json/v3/dns/edit/{domain}/{id}`.
         */
        public function edit_record( string $domain, int $record_id, string $type, string $name, string $content, int $ttl = 600, ?int $prio = null ) {
                $type    = strtoupper( sanitize_text_field( $type ) );
@@ -305,6 +313,9 @@ class Porkbun_Client {
 
        /**
         * Retrieve DNS records by subdomain and type.
+        *
+        * Uses Porkbun's v3 DNS retrieveByNameType endpoint:
+        * `/api/json/v3/dns/retrieveByNameType/{domain}/{type}/{subdomain}`.
         */
        public function retrieve_by_name_type( string $domain, string $subdomain, string $type ) {
                 $subdomain = sanitize_text_field( $subdomain );
@@ -314,6 +325,9 @@ class Porkbun_Client {
 
        /**
         * Edit or create a DNS record by subdomain and type.
+        *
+        * Uses Porkbun's v3 DNS editByNameType endpoint:
+        * `/api/json/v3/dns/editByNameType/{domain}/{type}/{subdomain}`.
         */
        public function edit_by_name_type( string $domain, string $subdomain, string $type, string $content, ?int $ttl = null ) {
                 $subdomain = sanitize_text_field( $subdomain );
@@ -340,10 +354,12 @@ class Porkbun_Client {
 
         /**
          * Delete a record by ID.
+         *
+         * Uses Porkbun's v3 DNS delete endpoint: `/api/json/v3/dns/delete/{domain}/{id}`.
          */
         public function delete_record( string $domain, int $record_id ) {
                 return $this->request( "dns/delete/{$domain}/{$record_id}", [] );
-	}
+        }
 
 	/**
 	 * Perform API request with retries and backoff.
@@ -561,6 +577,9 @@ class Porkbun_Client {
 
        /**
         * Delete DNS records by subdomain and type.
+        *
+        * Uses Porkbun's v3 DNS deleteByNameType endpoint:
+        * `/api/json/v3/dns/deleteByNameType/{domain}/{type}/{subdomain}`.
         */
        public function delete_by_name_type( string $domain, string $subdomain, string $type ) {
                $subdomain = sanitize_text_field( $subdomain );

--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.3.1
+ * Version:           0.4.0
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.3.1';
+const PORKPRESS_SSL_VERSION = '0.4.0';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 


### PR DESCRIPTION
## Summary
- bump plugin version to 0.4.0
- document DNS record CRUD and API v3 usage in README
- clarify v3 endpoints in inline comments

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_689e42feabf483339f633920fb7ec8d6