### PR TITLE
Add DNS retrieval AJAX handler and frontend fetch

### DIFF
--- a/assets/domain-details.js
+++ b/assets/domain-details.js
@@ -2,6 +2,10 @@ jQuery(function($){
     function render(records){
         var $tbody = $('#porkpress-dns-records tbody');
         $tbody.empty();
+        if(!Array.isArray(records)){
+            alert(porkpressDNS.i18n.error);
+            return;
+        }
         records.forEach(function(r){
             var row = '<tr data-id="'+r.id+'">'+
                 '<td><input type="text" class="dns-type" value="'+r.type+'" /></td>'+
@@ -18,13 +22,17 @@ jQuery(function($){
         data.action = 'porkpress_dns_'+action;
         data.nonce = porkpressDNS.nonce;
         data.domain = porkpressDNS.domain;
-        $.post(porkpressDNS.ajaxUrl, data, function(res){
-            if(res.success){
-                render(res.data.records);
-            }else{
-                alert(res.data);
-            }
-        });
+        $.post(porkpressDNS.ajaxUrl, data)
+            .done(function(res){
+                if(res.success){
+                    render(res.data.records);
+                }else{
+                    alert(res.data || porkpressDNS.i18n.error);
+                }
+            })
+            .fail(function(){
+                alert(porkpressDNS.i18n.error);
+            });
     }
     $('#porkpress-dns-records').on('click','.dns-add-btn', function(e){
         e.preventDefault();
@@ -55,4 +63,5 @@ jQuery(function($){
             record_id: $tr.data('id')
         });
     });
+    send('retrieve', {});
 });

--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -929,6 +929,36 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
        }
 
        /**
+        * Retrieve DNS records for a domain.
+        *
+        * @param string $domain Domain zone.
+        * @return array|Porkbun_Client_Error|\WP_Error List of records or error on failure.
+        */
+       public function get_dns_records( string $domain ) {
+               $domain = $this->validate_fqdn( $domain );
+               if ( false === $domain ) {
+                       return new \WP_Error( 'invalid_domain', __( 'Invalid domain name.', 'porkpress-ssl' ) );
+               }
+
+               try {
+                       $result = $this->client->get_records( $domain );
+               } catch ( \Throwable $e ) {
+                       $result = new Porkbun_Client_Error( 'client_error', $e->getMessage() );
+               }
+
+               if ( $result instanceof Porkbun_Client_Error ) {
+                       Logger::error(
+                               'get_dns_records',
+                               array( 'domain' => $domain ),
+                               $result->message
+                       );
+                       return $result;
+               }
+
+               return $result['records'] ?? array();
+       }
+
+       /**
         * Add a DNS record.
         *
         * @param string $domain  Domain zone.


### PR DESCRIPTION
## Summary
- add AJAX handler to retrieve DNS records from Porkbun
- expose Domain_Service::get_dns_records for direct API lookups
- fetch and render DNS records on page load with improved JS error handling

## Testing
- ⚠️ `phpunit tests` (66 tests, 1 warning)


------
https://chatgpt.com/codex/tasks/task_e_689e54c460988333a71103c6002fb2cd