### PR TITLE
Add datalist for unmapped domain aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ alias table automatically. When a site is created, deleted, archived or
 restored the plugin adjusts aliases and queues certificate issuance so SSL
 coverage remains in sync with the network.
 
+When assigning domains to sites via the Domain Aliases screen, the domain picker lists only Porkbun domains that are not already mapped.
+
 ## Debian 11/Apache example
 
 On Debian 11 with Apache, WordPress is typically installed under `/var/www/html`


### PR DESCRIPTION
## Summary
- Populate available domain aliases from Porkbun and filter out domains already mapped to sites
- Replace free-text alias input with datalist and validate selections
- Document that alias picker only lists unmapped domains

## Testing
- `php -l includes/class-admin.php`
- `phpunit` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689e67754b108333a38e3d1495240c4b