### PR TITLE
Fix domain duplication bug in domain list refresh

### DIFF
--- a/includes/class-domain-service.php
+++ b/includes/class-domain-service.php
@@ -531,7 +531,18 @@ private const DNS_PROPAGATION_OPTION = 'porkpress_ssl_dns_propagation';
                 if ( '' === $name || '@' === $name ) {
                     continue;
                 }
-                $fqdn = $name . '.' . $root;
+
+                $fqdn = $name;
+                $suffix = '.' . $root;
+
+                if ( $name !== $root ) {
+                    $name_len = strlen( $name );
+                    $suffix_len = strlen( $suffix );
+                    if ( $name_len < $suffix_len || substr( $name, -$suffix_len ) !== $suffix ) {
+                        $fqdn = $name . '.' . $root;
+                    }
+                }
+
                 $key  = strtolower( $fqdn );
                 if ( isset( $seen[ $key ] ) ) {
                     continue;


### PR DESCRIPTION
The `refresh_domains` method in `Domain_Service` incorrectly constructed Fully Qualified Domain Names (FQDNs). It assumed that the `name` field from the Porkbun API's DNS records was always a subdomain, and unconditionally appended the root domain.

However, for some records, the `name` field can be a FQDN. This resulted in incorrect entries like `example.com.example.com` being created and cached.

This change introduces a check to determine if the record `name` is already a FQDN (i.e., it is the same as the root domain or ends with `.<root_domain>`). The root domain is now only appended if the `name` is a partial subdomain, preventing the creation of malformed domain entries.