### PR TITLE
Improve certbot error handling and notifications

### DIFF
--- a/includes/class-ssl-service.php
+++ b/includes/class-ssl-service.php
@@ -133,6 +133,7 @@ class SSL_Service {
 
                $shards = self::shard_domains( $all_domains );
                $all_ok = true;
+               $user_id = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
                foreach ( $shards as $index => $names ) {
                        $cert_name = 'porkpress-shard-' . $index;
                        $cmd       = Renewal_Service::build_certbot_command( $names, $cert_name, $staging, false );
@@ -149,9 +150,12 @@ class SSL_Service {
                                Logger::error(
                                        'issue_certificate',
                                        array(
-                                               'site_ids' => $queue,
-                                               'domains'  => $names,
-                                               'output'   => $result['output'],
+                                               'cmd'     => $cmd,
+                                               'cert'    => $cert_name,
+                                               'site_ids'=> $queue,
+                                               'domains' => $names,
+                                               'output'  => $result['output'],
+                                               'user_id' => $user_id,
                                        ),
                                        'certbot failed'
                                );
@@ -165,8 +169,11 @@ class SSL_Service {
                                Logger::error(
                                        'issue_certificate',
                                        array(
-                                               'site_ids' => $queue,
-                                               'domains'  => $names,
+                                               'cmd'     => $cmd,
+                                               'cert'    => $cert_name,
+                                               'site_ids'=> $queue,
+                                               'domains' => $names,
+                                               'user_id' => $user_id,
                                        ),
                                        'post-deploy failed'
                                );
@@ -176,8 +183,11 @@ class SSL_Service {
                        Logger::info(
                                'issue_certificate',
                                array(
-                                       'site_ids' => $queue,
-                                       'domains'  => $names,
+                                       'cmd'     => $cmd,
+                                       'cert'    => $cert_name,
+                                       'site_ids'=> $queue,
+                                       'domains' => $names,
+                                       'user_id' => $user_id,
                                ),
                                'success'
                        );


### PR DESCRIPTION
## Summary
- Add structured logging, user context and notifications around certbot certificate listing
- Include command, domains and user info when renewing or deleting certificates via admin
- Log certbot commands and surface notices during issuance and renewal processes

## Testing
- `./vendor/bin/phpunit tests` *(fails: Cannot redeclare function get_site_option; DomainServiceTest::testListDomainsIncludesSubdomains; ReconcilerTest::testReconcileAllIncludesSubdomains)*

------
https://chatgpt.com/codex/tasks/task_e_689f611fffb483338265735efbcfbf20