### PR TITLE
Fix server IP handling in settings tab

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1376,19 +1376,29 @@ update_site_option( 'porkpress_ssl_state_root', sanitize_text_field( wp_unslash(
 $network_wildcard = isset( $_POST['porkpress_network_wildcard'] ) ? 1 : 0;
 update_site_option( 'porkpress_ssl_network_wildcard', $network_wildcard );
 
+$ipv4_override = get_site_option( 'porkpress_ssl_ipv4_override', '' );
 if ( isset( $_POST['porkpress_ipv4'] ) ) {
-    update_site_option( 'porkpress_ssl_ipv4_override', sanitize_text_field( wp_unslash( $_POST['porkpress_ipv4'] ) ) );
+    $ipv4_override = sanitize_text_field( wp_unslash( $_POST['porkpress_ipv4'] ) );
+    update_site_option( 'porkpress_ssl_ipv4_override', $ipv4_override );
 }
+$ipv6_override = get_site_option( 'porkpress_ssl_ipv6_override', '' );
 if ( isset( $_POST['porkpress_ipv6'] ) ) {
-    update_site_option( 'porkpress_ssl_ipv6_override', sanitize_text_field( wp_unslash( $_POST['porkpress_ipv6'] ) ) );
+    $ipv6_override = sanitize_text_field( wp_unslash( $_POST['porkpress_ipv6'] ) );
+    update_site_option( 'porkpress_ssl_ipv6_override', $ipv6_override );
 }
 
-            if ( isset( $_POST['porkpress_prod_server'] ) ) {
-                update_site_option( 'porkpress_ssl_prod_server_ip', sanitize_text_field( wp_unslash( $_POST['porkpress_prod_server'] ) ) );
-            }
-            if ( isset( $_POST['porkpress_dev_server'] ) ) {
-                update_site_option( 'porkpress_ssl_dev_server_ip', sanitize_text_field( wp_unslash( $_POST['porkpress_dev_server'] ) ) );
-            }
+           if ( isset( $_POST['porkpress_prod_server'] ) ) {
+               $prod_server_ip = sanitize_text_field( wp_unslash( $_POST['porkpress_prod_server'] ) );
+               if ( filter_var( $prod_server_ip, FILTER_VALIDATE_IP ) ) {
+                       update_site_option( 'porkpress_ssl_prod_server_ip', $prod_server_ip );
+               }
+           }
+           if ( isset( $_POST['porkpress_dev_server'] ) ) {
+               $dev_server_ip = sanitize_text_field( wp_unslash( $_POST['porkpress_dev_server'] ) );
+               if ( filter_var( $dev_server_ip, FILTER_VALIDATE_IP ) ) {
+                       update_site_option( 'porkpress_ssl_dev_server_ip', $dev_server_ip );
+               }
+           }
 
 $cert_name = get_site_option( 'porkpress_ssl_cert_name', defined( 'PORKPRESS_CERT_NAME' ) ? PORKPRESS_CERT_NAME : 'porkpress-network' );
 $cert_root = get_site_option( 'porkpress_ssl_cert_root', defined( 'PORKPRESS_CERT_ROOT' ) ? PORKPRESS_CERT_ROOT : '/etc/letsencrypt' );
@@ -1552,11 +1562,11 @@ echo '<td><input name="porkpress_ipv6" type="text" id="porkpress_ipv6" value="' 
 echo '</tr>';
 echo '<tr>';
 echo '<th scope="row"><label for="porkpress_prod_server">' . esc_html__( 'Production Server', 'porkpress-ssl' ) . '</label></th>';
-echo '<td><input name="porkpress_prod_server" type="text" id="porkpress_prod_server" value="' . esc_attr( $prod_server ) . '" class="regular-text" /></td>';
+echo '<td><input name="porkpress_prod_server" type="text" id="porkpress_prod_server" value="' . esc_attr( $prod_server_ip ) . '" class="regular-text" /></td>';
 echo '</tr>';
 echo '<tr>';
 echo '<th scope="row"><label for="porkpress_dev_server">' . esc_html__( 'Development Server', 'porkpress-ssl' ) . '</label></th>';
-echo '<td><input name="porkpress_dev_server" type="text" id="porkpress_dev_server" value="' . esc_attr( $dev_server ) . '" class="regular-text" /></td>';
+echo '<td><input name="porkpress_dev_server" type="text" id="porkpress_dev_server" value="' . esc_attr( $dev_server_ip ) . '" class="regular-text" /></td>';
 echo '</tr>';
 echo '<tr>';
         echo '<th scope="row">' . esc_html__( 'Automatic Reconciliation', 'porkpress-ssl' ) . '</th>';

--- a/tests/RenderSettingsTabTest.php
+++ b/tests/RenderSettingsTabTest.php
@@ -63,4 +63,63 @@ CODE
         $this->assertStringContainsString( 'value="1.2.3.4"', $output );
         $this->assertStringContainsString( 'value="2001:db8::1"', $output );
     }
+
+    public function testPostingServerIpsReappear() {
+        if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', __DIR__ ); }
+        if ( ! defined( 'PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS' ) ) {
+            define( 'PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS', 'manage_network' );
+        }
+        if ( ! defined( 'PORKPRESS_SSL_VERSION' ) ) {
+            define( 'PORKPRESS_SSL_VERSION', '1.0.0' );
+        }
+        eval(<<<'CODE'
+namespace PorkPress\SSL;
+class Logger { public static function info( ...$args ) {} }
+class Renewal_Service {
+    public static function maybe_schedule( $force = false ) {}
+    public static function get_apache_reload_cmd() { return ''; }
+}
+class Certbot_Helper { public static function list_certificates() { return array(); } }
+function update_site_option( $key, $value ) { $GLOBALS['porkpress_site_options'][ $key ] = $value; }
+function get_site_option( $key, $default = '' ) { return $GLOBALS['porkpress_site_options'][ $key ] ?? $default; }
+function check_admin_referer( $action, $name = '' ) { return true; }
+function wp_unslash( $v ) { return $v; }
+function sanitize_text_field( $v ) { return $v; }
+function absint( $v ) { return (int) $v; }
+function esc_html__( $t, $d = null ) { return $t; }
+function esc_html( $t ) { return $t; }
+function esc_attr__( $t, $d = null ) { return $t; }
+function esc_attr( $t ) { return $t; }
+function __( $t, $d = null ) { return $t; }
+function checked( $checked, $current = true, $echo = false ) { return ''; }
+function wp_nonce_field( $action, $name = '', $referer = true, $echo = true ) {}
+function submit_button( $text = null, $type = '', $name = '', $wrap = true ) {}
+function current_user_can( $cap ) { return true; }
+CODE
+        );
+        require_once __DIR__ . '/../includes/class-admin.php';
+
+        $GLOBALS['porkpress_site_options'] = array();
+
+        $_POST = array(
+            'porkpress_ssl_settings_nonce' => 'nonce',
+            'porkpress_prod_server' => '10.0.0.1',
+            'porkpress_dev_server'  => '10.0.0.2',
+        );
+
+        $admin = new \PorkPress\SSL\Admin();
+        ob_start();
+        $admin->render_settings_tab();
+        ob_end_clean();
+
+        $this->assertSame( '10.0.0.1', $GLOBALS['porkpress_site_options']['porkpress_ssl_prod_server_ip'] );
+        $this->assertSame( '10.0.0.2', $GLOBALS['porkpress_site_options']['porkpress_ssl_dev_server_ip'] );
+
+        $_POST = array();
+        ob_start();
+        $admin->render_settings_tab();
+        $output = ob_get_clean();
+        $this->assertStringContainsString( 'value="10.0.0.1"', $output );
+        $this->assertStringContainsString( 'value="10.0.0.2"', $output );
+    }
 }


### PR DESCRIPTION
## Summary
- use prod/dev server IP variables when rendering settings form
- validate server IP addresses before saving to options
- test that saved server IPs are shown in settings form

## Testing
- `vendor/bin/phpunit tests/RenderSettingsTabTest.php`
- `vendor/bin/phpunit tests` *(fails: Cannot redeclare class/function errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f6d733fa8833396104879242125d4