### PR TITLE
Ensure IP overrides defined before logging

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1376,14 +1376,17 @@ update_site_option( 'porkpress_ssl_state_root', sanitize_text_field( wp_unslash(
 $network_wildcard = isset( $_POST['porkpress_network_wildcard'] ) ? 1 : 0;
 update_site_option( 'porkpress_ssl_network_wildcard', $network_wildcard );
 
-$ipv4_override = get_site_option( 'porkpress_ssl_ipv4_override', '' );
+$ipv4_override = isset( $_POST['porkpress_ipv4'] )
+    ? sanitize_text_field( wp_unslash( $_POST['porkpress_ipv4'] ) )
+    : get_site_option( 'porkpress_ssl_ipv4_override', '' );
 if ( isset( $_POST['porkpress_ipv4'] ) ) {
-    $ipv4_override = sanitize_text_field( wp_unslash( $_POST['porkpress_ipv4'] ) );
     update_site_option( 'porkpress_ssl_ipv4_override', $ipv4_override );
 }
-$ipv6_override = get_site_option( 'porkpress_ssl_ipv6_override', '' );
+
+$ipv6_override = isset( $_POST['porkpress_ipv6'] )
+    ? sanitize_text_field( wp_unslash( $_POST['porkpress_ipv6'] ) )
+    : get_site_option( 'porkpress_ssl_ipv6_override', '' );
 if ( isset( $_POST['porkpress_ipv6'] ) ) {
-    $ipv6_override = sanitize_text_field( wp_unslash( $_POST['porkpress_ipv6'] ) );
     update_site_option( 'porkpress_ssl_ipv6_override', $ipv6_override );
 }
 

--- a/tests/RenderSettingsTabTest.php
+++ b/tests/RenderSettingsTabTest.php
@@ -5,6 +5,64 @@ use PHPUnit\Framework\TestCase;
  * @runTestsInSeparateProcesses
  */
 class RenderSettingsTabTest extends TestCase {
+    public function testSavingSettingsDoesNotTriggerNotices() {
+        if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', __DIR__ ); }
+        if ( ! defined( 'PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS' ) ) {
+            define( 'PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS', 'manage_network' );
+        }
+        if ( ! defined( 'PORKPRESS_SSL_VERSION' ) ) {
+            define( 'PORKPRESS_SSL_VERSION', '1.0.0' );
+        }
+        eval(<<<'CODE'
+namespace PorkPress\SSL;
+class Logger { public static function info( ...$args ) {} }
+class Renewal_Service {
+    public static function maybe_schedule( $force = false ) {}
+    public static function get_apache_reload_cmd() { return ''; }
+}
+class Certbot_Helper { public static function list_certificates() { return array(); } }
+function update_site_option( $key, $value ) { $GLOBALS['porkpress_site_options'][ $key ] = $value; }
+function get_site_option( $key, $default = '' ) { return $GLOBALS['porkpress_site_options'][ $key ] ?? $default; }
+function check_admin_referer( $action, $name = '' ) { return true; }
+function wp_unslash( $v ) { return $v; }
+function sanitize_text_field( $v ) { return $v; }
+function absint( $v ) { return (int) $v; }
+function esc_html__( $t, $d = null ) { return $t; }
+function esc_html( $t ) { return $t; }
+function esc_attr__( $t, $d = null ) { return $t; }
+function esc_attr( $t ) { return $t; }
+function __( $t, $d = null ) { return $t; }
+function checked( $checked, $current = true, $echo = false ) { return ''; }
+function wp_nonce_field( $action, $name = '', $referer = true, $echo = true ) {}
+function submit_button( $text = null, $type = '', $name = '', $wrap = true ) {}
+function current_user_can( $cap ) { return true; }
+CODE
+        );
+        require_once __DIR__ . '/../includes/class-admin.php';
+
+        $GLOBALS['porkpress_site_options'] = array();
+
+        $_POST = array(
+            'porkpress_ssl_settings_nonce' => 'nonce',
+        );
+
+        $admin = new \PorkPress\SSL\Admin();
+
+        set_error_handler( function ( $errno, $errstr ) {
+            if ( E_NOTICE === $errno ) {
+                throw new \RuntimeException( $errstr );
+            }
+            return false;
+        } );
+
+        ob_start();
+        $admin->render_settings_tab();
+        ob_end_clean();
+
+        restore_error_handler();
+
+        $this->addToAssertionCount( 1 );
+    }
     public function testPostingIpvOverridesUpdatesOptions() {
         if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', __DIR__ ); }
         if ( ! defined( 'PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS' ) ) {


### PR DESCRIPTION
## Summary
- Ensure IPv4/IPv6 override settings are sanitized and initialized before logging
- Add regression test to prevent "undefined variable" notices when saving settings

## Testing
- `./vendor/bin/phpunit tests/RenderSettingsTabTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689f779bbf908333a167237aa6a61c55