### PR TITLE
Respect custom certbot path in list command

### DIFF
--- a/includes/class-certbot-helper.php
+++ b/includes/class-certbot-helper.php
@@ -81,9 +81,10 @@ class Certbot_Helper {
      * @return array<string, array{domains: array<int, string>, expiry: string, status: string}>
      */
     public static function list_certificates(): array {
-        $cmd    = 'certbot certificates';
-        $result = Runner::run( $cmd . ' 2>/dev/null', 'certbot' );
-        $user   = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
+        $certbot_cmd = function_exists( '\\get_site_option' ) ? \get_site_option( 'porkpress_ssl_certbot_cmd', 'certbot' ) : 'certbot';
+        $cmd         = escapeshellcmd( $certbot_cmd ) . ' certificates';
+        $result      = Runner::run( $cmd . ' 2>/dev/null', 'certbot' );
+        $user        = function_exists( 'get_current_user_id' ) ? (int) get_current_user_id() : 0;
 
         if ( 0 !== $result['code'] ) {
             Logger::error(


### PR DESCRIPTION
## Summary
- use porkpress_ssl_certbot_cmd option when listing existing certificates
- add test ensuring Certbot_Helper honors non-default certbot path for listing

## Testing
- `vendor/bin/phpunit tests/CertbotHelperTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689f7aa88e8c83339eb32a6af5a57865