### PR TITLE
Add per-domain server IP tracking

### DIFF
--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -59,6 +59,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 function porkpress_ssl_activate() {
         \PorkPress\SSL\Logger::create_table();
        \PorkPress\SSL\Domain_Service::create_alias_table();
+       \PorkPress\SSL\Domain_Service::create_server_table();
        if ( ! wp_next_scheduled( 'porkpress_ssl_reconcile' ) ) {
                wp_schedule_event( time(), 'daily', 'porkpress_ssl_reconcile' );
        }
@@ -175,6 +176,11 @@ function porkpress_ssl_init() {
        $alias_table = \PorkPress\SSL\Domain_Service::get_alias_table_name();
        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $alias_table ) ) !== $alias_table ) {
                \PorkPress\SSL\Domain_Service::create_alias_table();
+       }
+
+       $server_table = \PorkPress\SSL\Domain_Service::get_server_table_name();
+       if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $server_table ) ) !== $server_table ) {
+               \PorkPress\SSL\Domain_Service::create_server_table();
        }
 
        $admin = new \PorkPress\SSL\Admin();

--- a/tests/DomainServiceTest.php
+++ b/tests/DomainServiceTest.php
@@ -883,18 +883,14 @@ class DomainServiceTest extends TestCase {
                 array( 'type' => 'A', 'ip' => '4.4.4.4' ),
             ),
         );
-        update_site_option( 'porkpress_ssl_prod_server_ip', '3.3.3.3' );
-        update_site_option( 'porkpress_ssl_dev_server_ip', '4.4.4.4' );
-
+        $wpdb = new \MockWpdb();
         $service = new class extends \PorkPress\SSL\Domain_Service {
             public function __construct() { $this->missing_credentials = false; }
         };
+        $service->set_server_ips( 'domain.test', '3.3.3.3', '4.4.4.4' );
 
         $result = $service->check_dns_health( 'domain.test' );
         $this->assertTrue( $result );
-
-        update_site_option( 'porkpress_ssl_prod_server_ip', '' );
-        update_site_option( 'porkpress_ssl_dev_server_ip', '' );
     }
 
     public function testCheckDnsHealthUsesDigFallbackWhenDnsGetRecordMissing() {

--- a/tests/RenderSettingsTabTest.php
+++ b/tests/RenderSettingsTabTest.php
@@ -21,6 +21,15 @@ class Renewal_Service {
     public static function get_apache_reload_cmd() { return ''; }
 }
 class Certbot_Helper { public static function list_certificates() { return array(); } }
+class Domain_Service {
+    public static $servers = array();
+    public function get_server_ips( string $domain = '' ): array {
+        return self::$servers[ $domain ] ?? array( 'prod_server_ip' => '', 'dev_server_ip' => '' );
+    }
+    public function set_server_ips( string $domain, string $prod, string $dev ): void {
+        self::$servers[ $domain ] = array( 'prod_server_ip' => $prod, 'dev_server_ip' => $dev );
+    }
+}
 function update_site_option( $key, $value ) { $GLOBALS['porkpress_site_options'][ $key ] = $value; }
 function get_site_option( $key, $default = '' ) { return $GLOBALS['porkpress_site_options'][ $key ] ?? $default; }
 function check_admin_referer( $action, $name = '' ) { return true; }
@@ -79,6 +88,15 @@ class Renewal_Service {
     public static function get_apache_reload_cmd() { return ''; }
 }
 class Certbot_Helper { public static function list_certificates() { return array(); } }
+class Domain_Service {
+    public static $servers = array();
+    public function get_server_ips( string $domain = '' ): array {
+        return self::$servers[ $domain ] ?? array( 'prod_server_ip' => '', 'dev_server_ip' => '' );
+    }
+    public function set_server_ips( string $domain, string $prod, string $dev ): void {
+        self::$servers[ $domain ] = array( 'prod_server_ip' => $prod, 'dev_server_ip' => $dev );
+    }
+}
 function update_site_option( $key, $value ) { $GLOBALS['porkpress_site_options'][ $key ] = $value; }
 function get_site_option( $key, $default = '' ) { return $GLOBALS['porkpress_site_options'][ $key ] ?? $default; }
 function check_admin_referer( $action, $name = '' ) { return true; }
@@ -138,6 +156,15 @@ class Renewal_Service {
     public static function get_apache_reload_cmd() { return ''; }
 }
 class Certbot_Helper { public static function list_certificates() { return array(); } }
+class Domain_Service {
+    public static $servers = array();
+    public function get_server_ips( string $domain = '' ): array {
+        return self::$servers[ $domain ] ?? array( 'prod_server_ip' => '', 'dev_server_ip' => '' );
+    }
+    public function set_server_ips( string $domain, string $prod, string $dev ): void {
+        self::$servers[ $domain ] = array( 'prod_server_ip' => $prod, 'dev_server_ip' => $dev );
+    }
+}
 function update_site_option( $key, $value ) { $GLOBALS['porkpress_site_options'][ $key ] = $value; }
 function get_site_option( $key, $default = '' ) { return $GLOBALS['porkpress_site_options'][ $key ] ?? $default; }
 function check_admin_referer( $action, $name = '' ) { return true; }
@@ -170,8 +197,8 @@ CODE
         $admin->render_settings_tab();
         ob_end_clean();
 
-        $this->assertSame( '10.0.0.1', $GLOBALS['porkpress_site_options']['porkpress_ssl_prod_server_ip'] );
-        $this->assertSame( '10.0.0.2', $GLOBALS['porkpress_site_options']['porkpress_ssl_dev_server_ip'] );
+        $this->assertSame( '10.0.0.1', \PorkPress\SSL\Domain_Service::$servers['']['prod_server_ip'] );
+        $this->assertSame( '10.0.0.2', \PorkPress\SSL\Domain_Service::$servers['']['dev_server_ip'] );
 
         $_POST = array();
         ob_start();


### PR DESCRIPTION
## Summary
- add `porkpress_domain_servers` table with CRUD helpers in `Domain_Service`
- persist server IPs via `Admin::render_settings_tab` and display them in domain listing
- create server table on activation and ensure during init

## Testing
- `./vendor/bin/phpunit tests/RenderSettingsTabTest.php --dont-report-useless-tests`
- `./vendor/bin/phpunit tests/RenderDomainsTabTest.php --dont-report-useless-tests`
- `./vendor/bin/phpunit tests/DomainServiceTest.php --dont-report-useless-tests` *(fails: Undefined array key "root_domains" and others)*
- `./vendor/bin/phpunit tests --dont-report-useless-tests` *(fails: multiple redeclaration errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f82e570dc8333ad5ebeee7f30c4f1