### PR TITLE
Capture stderr for certbot failures and bump version

### DIFF
--- a/porkpress-ssl.php
+++ b/porkpress-ssl.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       PorkPress SSL
  * Description:       Manage SSL certificates via Porkbun.
- * Version:           0.5.0
+ * Version:           0.6.0
  * Requires at least: 6.0
  * Requires PHP:      8.1
  * Network:           true
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-const PORKPRESS_SSL_VERSION = '0.5.0';
+const PORKPRESS_SSL_VERSION = '0.6.0';
 const PORKPRESS_SSL_CAP_MANAGE_NETWORK_DOMAINS = 'manage_network_domains';
 const PORKPRESS_SSL_CAP_REQUEST_DOMAIN       = 'request_domain';
 


### PR DESCRIPTION
## Summary
- Capture stdout/stderr separately in runner and propagate stderr in certbot list logging
- Show admin notice when certbot list fails and hint when certbot is missing
- Add regression test for list failure notice
- Bump plugin version to 0.6.0

## Testing
- `./vendor/bin/phpunit tests/CertbotHelperTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689f86299ef483338bb8d8d4e9aa6913