### PR TITLE
Show empty server column for unmatched domains

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -839,8 +839,8 @@ add_action( 'admin_notices', array( $this, 'sunrise_notice' ) );
                                echo '<td>' . esc_html( $prod_server_ip ) . '</td>';
                                echo '<td>' . esc_html( $dev_server_ip ) . '</td>';
 
-                               $server = 'N/A';
-                               $all_records = array_merge( $records, ...array_map( fn($s) => $s['dns'] ?? [], $subdomains ) );
+                               $server = '';
+                               $all_records = array_merge( $records, ...array_map( fn ( $s ) => $s['dns'] ?? [], $subdomains ) );
                                foreach ( $all_records as $record ) {
                                    if ( 'A' === $record['type'] ) {
                                        if ( ! empty( $prod_server_ip ) && $record['content'] === $prod_server_ip ) {


### PR DESCRIPTION
## Summary
- Display a blank server column for domains whose A records don't match saved server IPs

## Testing
- `vendor/bin/phpunit tests` *(fails: Fatal error: Cannot redeclare class PorkPress\SSL\Domain_Service...)*

------
https://chatgpt.com/codex/tasks/task_e_689fe9c544c88333b9fd63bf094fa6b0