### PR TITLE
Hide server IP columns in domain list

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -831,9 +831,18 @@ add_action( 'admin_notices', array( $this, 'sunrise_notice' ) );
                                               }
                                       }
                               }
-                              $alias_info     = $alias_map[ strtolower( $name ) ] ?? array();
-                              $prod_server_ip = $alias_info['prod_server_ip'] ?? $default_ips['prod_server_ip'];
-                              $dev_server_ip  = $alias_info['dev_server_ip']  ?? $default_ips['dev_server_ip'];
+                              $alias_info = $alias_map[ strtolower( $name ) ] ?? array();
+                              $domain_ips = $service->get_server_ips( $name );
+                              $prod_server_ip = ! empty( $alias_info['prod_server_ip'] )
+                                      ? $alias_info['prod_server_ip']
+                                      : ( ! empty( $domain_ips['prod_server_ip'] )
+                                              ? $domain_ips['prod_server_ip']
+                                              : $default_ips['prod_server_ip'] );
+                              $dev_server_ip  = ! empty( $alias_info['dev_server_ip'] )
+                                      ? $alias_info['dev_server_ip']
+                                      : ( ! empty( $domain_ips['dev_server_ip'] )
+                                              ? $domain_ips['dev_server_ip']
+                                              : $default_ips['dev_server_ip'] );
 
                                echo '<td>' . $site_cell . '</td>';
 

--- a/tests/RenderDomainsTabTest.php
+++ b/tests/RenderDomainsTabTest.php
@@ -50,6 +50,10 @@ class Domain_Service {
             self::$domains
         ) );
     }
+    public function get_server_ips( string $domain = '' ): array {
+        $domain = strtolower( $domain );
+        return self::$servers[ $domain ] ?? array( 'prod_server_ip' => '', 'dev_server_ip' => '' );
+    }
     public function get_last_refresh() { return 0; }
 }
 function get_sites( $args ) { return array(); }


### PR DESCRIPTION
## Summary
- fetch per-domain server IPs via `Domain_Service::get_server_ips()` while omitting Prod/Dev IP table columns
- update RenderDomainsTab test stub for new IP lookup

## Testing
- `php -l includes/class-admin.php`
- `php -l tests/RenderDomainsTabTest.php`
- `./vendor/bin/phpunit tests/RenderDomainsTabTest.php`
- `./vendor/bin/phpunit tests` *(fails: Cannot redeclare classes and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b45ae860748333a3a6871c20cb68b7