### PR TITLE
Fix admin logs tab table lookup

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1702,7 +1702,7 @@ echo '</tr>';
                 }
 
                 global $wpdb;
-                $table_name = $wpdb->prefix . 'porkpress_logs';
+                $table_name = Logger::get_table_name();
 
                if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
                         printf( '<div class="error"><p>%s</p></div>', esc_html__( 'Logs table does not exist.', 'porkpress-ssl' ) );


### PR DESCRIPTION
## Summary
- use the shared logger table helper when checking for the logs table

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da0578a4083338299f2ffeeceb17c)