### PR TITLE
Clear manifest when deleting certificate manually

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1225,6 +1225,20 @@ if ( isset( $base_cmds[ $action ] ) ) {
                 'manual_required'
         );
 
+        if ( 'delete' === $action ) {
+                $state_root = get_site_option(
+                        'porkpress_ssl_state_root',
+                        defined( 'PORKPRESS_STATE_ROOT' ) ? PORKPRESS_STATE_ROOT : '/var/lib/porkpress-ssl'
+                );
+                $manifest = rtrim( $state_root, '/\\' ) . '/manifest.json';
+                if ( file_exists( $manifest ) ) {
+                        $data = json_decode( file_get_contents( $manifest ), true );
+                        if ( is_array( $data ) && ( $data['cert_name'] ?? '' ) === $cert ) {
+                                @unlink( $manifest );
+                        }
+                }
+        }
+
         Notifier::notify(
                 'warning',
                 __( 'Run SSL command manually', 'porkpress-ssl' ),


### PR DESCRIPTION
## Summary
- remove the SSL manifest when the admin triggers a manual delete to prevent stale renewals

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69553c1784c8833388a208321ffc2542)